### PR TITLE
fix: corrigir nome do arquivo de configuração do CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,7 +8,7 @@ reviews:
   collapse_walkthrough: false
   auto_review:
     enabled: true
-    drafts: false
+    drafts: true
     base_branches:
       - main
       - develop

--- a/coderabbit.yaml
+++ b/coderabbit.yaml
@@ -1,0 +1,20 @@
+language: "pt-BR"
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+      - develop
+instructions: |
+  Este é um projeto acadêmico de módulo nutricional hospitalar.
+  Stack: Python, Flask, SQLAlchemy, PostgreSQL.
+  Siga os padrões da arquitetura em camadas: routes → services → repository → models.
+  Verifique: boas práticas Python, segurança, performance em queries SQL,
+  nomenclatura em português para variáveis de domínio clínico.


### PR DESCRIPTION
## Problema

O CodeRabbit ignorava o arquivo de configuração porque o nome estava errado (`coderabbit.yaml` em vez de `.coderabbit.yaml`). Por isso, PRs direcionados à branch `develop` não eram analisados — o CodeRabbit caía no comportamento padrão e só analisava a branch default.

## Alterações

- Renomeado `coderabbit.yaml` → `.coderabbit.yaml`
- Habilitada análise de PRs em draft (`drafts: true`)

## Resultado esperado

Após o merge, o CodeRabbit vai analisar automaticamente PRs com base em `main` e `develop`, incluindo drafts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration settings to enhance the code review workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->