### PR TITLE
fix: fix major issue in the file nutritional_nrs_service.py

### DIFF
--- a/services/nutritional/nutritional_nrs_service.py
+++ b/services/nutritional/nutritional_nrs_service.py
@@ -107,8 +107,8 @@ def _score_nrs_component_b(
     if not cid:
         return 0
 
+    mappings: CidMappings = get_cid_mappings_cached_fn()
     if len(cid) >= 3:
-        mappings: CidMappings = get_cid_mappings_cached_fn()
         prefix3: str = cid[:3]
         if prefix3 in mappings.overrides:
             return mappings.overrides[prefix3]

--- a/tests/unit/test_nutritional_nrs_service.py
+++ b/tests/unit/test_nutritional_nrs_service.py
@@ -248,14 +248,15 @@ def test_internal_component_b_returns_zero_when_chapter_not_mapped() -> None:
     assert result == 0
 
 
-def test_internal_component_b_len_lt_3_current_behavior_raises_unboundlocalerror(
+def test_internal_component_b_len_lt_3_uses_chapter_score(
     cid_mappings: svc.CidMappings,
 ) -> None:
     is_uti_fn = MagicMock(return_value=False)
     get_mappings_fn = MagicMock(return_value=cid_mappings)
 
-    with pytest.raises(UnboundLocalError):
-        svc._score_nrs_component_b(1, "A", is_uti_fn, get_mappings_fn)
+    result = svc._score_nrs_component_b(1, "A", is_uti_fn, get_mappings_fn)
+
+    assert result == 1
 
 
 # 8) calculate_age


### PR DESCRIPTION
# US-BE-04 | Correção de bug no NRS-2002 (CID curto)

## Resumo
Esta PR corrige um bug crítico no cálculo do **Componente B** do NRS-2002 para CIDs com tamanho menor que 3 caracteres.

Antes, em cenários específicos, a função interna `_score_nrs_component_b` podia lançar `UnboundLocalError` ao processar CID curto.
Agora, o cálculo trata esse caso de forma explícita e segue o comportamento esperado: **fallback para score por capítulo** (primeiro caractere do CID), sem interromper o fluxo.

---

## Problema identificado
- O teste antigo documentava comportamento de defeito (esperava exceção).
- A regra de negócio esperada é **não quebrar** para CID curto e continuar com classificação por capítulo.

---

## O que foi ajustado

### 1) Regra do componente B (CID curto)
Arquivo alterado:
- `services/nutritional/nutritional_nrs_service.py`

Comportamento esperado após correção:
1. Se paciente estiver em UTI: retorna `3`.
2. Se CID vazio: retorna `0`.
3. Se CID tiver 3+ caracteres e houver override por prefixo: retorna override.
4. Caso contrário (incluindo CID curto), usa capítulo (`cid[0]`) e aplica score de `chapters`.

---

### 2) Atualização de teste unitário
Arquivo alterado:
- `tests/unit/test_nutritional_nrs_service.py`

Teste atualizado:
- De: `test_internal_component_b_len_lt_3_current_behavior_raises_unboundlocalerror`
- Para: `test_internal_component_b_len_lt_3_uses_chapter_score`

Validação atual:
- Para CID curto (ex.: `"A"`), a função retorna score por capítulo (ex.: `1`) em vez de lançar exceção.

---

## Impacto
- Remove falha em runtime para entrada válida porém curta.
- Mantém compatibilidade com a lógica de override e fallback existentes.
- Melhora robustez do cálculo clínico sem alterar contratos externos.

---

## Risco
**Baixo**.
Mudança pontual em regra já coberta por testes unitários da mesma unidade de serviço.

---

## Checklist
- [x] Bug reproduzido e analisado
- [x] Correção aplicada no cálculo do componente B
- [x] Teste atualizado para comportamento esperado
- [x] Sem mudança de contrato público da API
- [x] Pronto para code review

---

## Observações para revisão
- Branch sugerida: `fix/US-BE-04-nrs-2002-engine`
- Base: `develop`
- Tipo: `fix` (correção de defeito em produção de regra de score)
