### PR TITLE
fix: correções motor nutricional NITRA (US-BE-05, US-BE-06, US-BE-07)

### DIFF
--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -21,11 +21,13 @@ def configure_logging():
         logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
         logging.getLogger("noharm.backend").setLevel(logging.WARNING)
         logging.getLogger("noharm.performance").setLevel(logging.WARNING)
+        logging.getLogger("noharm.nutritional").setLevel(logging.INFO)
         logging.getLogger("boto3").setLevel(logging.WARNING)
         logging.getLogger("botocore").setLevel(logging.WARNING)
     else:
         logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
         logging.getLogger("noharm.backend").setLevel(logging.DEBUG)
         logging.getLogger("noharm.performance").setLevel(logging.DEBUG)
+        logging.getLogger("noharm.nutritional").setLevel(logging.INFO)
         logging.getLogger("boto3").setLevel(logging.INFO)
         logging.getLogger("botocore").setLevel(logging.INFO)

--- a/decorators/api_endpoint_decorator.py
+++ b/decorators/api_endpoint_decorator.py
@@ -40,7 +40,7 @@ def api_endpoint(download_headers=None, is_admin=False, include_total=False):
                 result = f(*args, **kwargs)
 
                 # should check for permission at least once
-                if g.get("permission_test_count", 0) == 0:
+                if not is_admin and g.get("permission_test_count", 0) == 0:
                     raise AuthorizationError()
 
                 db.session.commit()

--- a/docker-compose.nitra.yml
+++ b/docker-compose.nitra.yml
@@ -27,7 +27,7 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ${DATABASE_PATH:-/Users/willian/Documents/github/nitra/database}:/sql # path para o projeto do database
+      - ${DATABASE_PATH:-/workspaces/nutricao-backend/database}:/sql # path para o projeto do database
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 5s
@@ -39,7 +39,7 @@ services:
       db:
         condition: service_healthy
     volumes:
-      - ${DATABASE_PATH:-/Users/willian/Documents/github/nitra/database}:/sql # path para o projeto do database
+      - ${DATABASE_PATH:-/workspaces/nutricao-backend/database}:/sql # path para o projeto do database
     entrypoint: >
       sh -c "
       psql -h db -U postgres -d noharm -f /sql/noharm-public.sql &&

--- a/repository/nutritional/nutritional_repository.py
+++ b/repository/nutritional/nutritional_repository.py
@@ -48,6 +48,11 @@ def get_patients_repository():
 
 
 def save_manual_mnutric(admission_number: int, mnutric: dict):
+    """Persiste entrada manual do nutricionista (PUT /mnutric-manual).
+
+    Seta mn_apache_manual=True e mn_sofa_manual=True sinalizando que
+    APACHE II e SOFA foram informados — libera dados_incompletos=False no frontend.
+    """
     if not _is_nutritional_screening_table_ready():
         return None
 
@@ -64,15 +69,54 @@ def save_manual_mnutric(admission_number: int, mnutric: dict):
         screening.protocolo = "MNUTRIC"
         db.session.add(screening)
 
-    screening.mn_idade = mnutric["age"]
     screening.mn_apache = mnutric["apache"]
     screening.mn_sofa = mnutric["sofa"]
+    screening.mn_apache_manual = True
+    screening.mn_sofa_manual = True
+    screening.mn_idade = mnutric["age"]
     screening.mn_comor = mnutric["comorbity"]
     screening.mn_dias = mnutric["daysUTI"]
     screening.mn_total = mnutric["total"]
-    screening.mn_apache_manual = True
-    screening.mn_sofa_manual = True
     screening.classificacao = mnutric["classify"]
+
+    db.session.flush()
+
+    return screening
+
+
+def update_mnutric_scores(admission_number: int, mnutric: dict):
+    """Atualiza scores calculados pelo job periódico.
+
+    Preserva mn_apache, mn_sofa e os flags mn_apache_manual/mn_sofa_manual —
+    somente o job chama esta função. Não altera a condição dados_incompletos.
+    """
+    if not _is_nutritional_screening_table_ready():
+        return None
+
+    screening = (
+        db.session.query(NutritionalScreening)
+        .filter(NutritionalScreening.nratendimento == admission_number)
+        .filter(NutritionalScreening.protocolo == "MNUTRIC")
+        .order_by(NutritionalScreening.id.desc())
+        .first()
+    )
+
+    if screening is None:
+        screening = NutritionalScreening()
+        screening.nratendimento = admission_number
+        screening.protocolo = "MNUTRIC"
+        screening.mn_apache_manual = False
+        screening.mn_sofa_manual = False
+        db.session.add(screening)
+
+    screening.mn_idade = mnutric["age"]
+    screening.mn_comor = mnutric["comorbity"]
+    screening.mn_dias = mnutric["daysUTI"]
+
+    dados_incompletos = not screening.mn_apache_manual or not screening.mn_sofa_manual
+    if not dados_incompletos:
+        screening.mn_total = mnutric["total"]
+        screening.classificacao = mnutric["classify"]
 
     db.session.flush()
 
@@ -90,7 +134,7 @@ def get_saved_mnutric(admission_number: int):
         .first()
     )
 
-def get_active_admissions():
+def get_active_admissions(schema: str):
     """Return all active admissions with ICU protocol flag.
 
     Active means dtalta IS NULL. Uses LEFT JOINs on segmentosetor and segmento
@@ -102,6 +146,7 @@ def get_active_admissions():
             nratendimento, fksetor, dtnascimento, dtinternacao,
             peso, altura, idcid, tp_segmento (int|None), is_icu (bool)
     """
+    db.session.execute(text(f'SET LOCAL search_path TO "{schema}"'))
     query = text(
         """
         SELECT
@@ -115,7 +160,7 @@ def get_active_admissions():
             p.dt_ultima_transferencia,
             seg.tp_segmento,
             COALESCE(seg.tp_segmento = :icu_type, false) AS is_icu
-        FROM demo."pessoa" p
+        FROM pessoa p
         LEFT JOIN segmentosetor ss  ON ss.fksetor     = p.fksetor
         LEFT JOIN segmento seg      ON seg.idsegmento  = ss.idsegmento
         WHERE p.dtalta IS NULL

--- a/repository/nutritional_patients_repository.py
+++ b/repository/nutritional_patients_repository.py
@@ -20,7 +20,7 @@ def get_patients(setor=None, ala=None):
     # Derive ala label from segment type
     ala_label = case(
         (Segment.type == SegmentTypeEnum.ICU.value, literal("UTI")),
-        else_=literal("Enfermaria"),
+        else_=Segment.description,
     ).label("ala")
 
     # haval
@@ -55,7 +55,7 @@ def get_patients(setor=None, ala=None):
         db.session.query(NutritionalScreening.classificacao)
         .filter(NutritionalScreening.nratendimento == Patient.admissionNumber)
         .correlate(Patient)
-        .order_by(NutritionalScreening.created_at.desc())
+        .order_by(NutritionalScreening.id.desc())
         .limit(1)
         .scalar_subquery()
     ).label("sev")
@@ -88,6 +88,46 @@ def get_patients(setor=None, ala=None):
         .scalar_subquery()
     ).label("glim_etiol")
 
+    # campo1 — NRS-2002 score fields from latest NRS2002 screening row
+    nrs_data_subq = (
+        db.session.query(
+            func.json_build_object(
+                "nrs_total", NutritionalScreening.nrs_total,
+                "nrs_nut", NutritionalScreening.nrs_nut,
+                "nrs_doenca", NutritionalScreening.nrs_doenca,
+                "nrs_idade", NutritionalScreening.nrs_idade,
+            )
+        )
+        .filter(NutritionalScreening.nratendimento == Patient.admissionNumber)
+        .filter(NutritionalScreening.protocolo == "NRS2002")
+        .correlate(Patient)
+        .order_by(NutritionalScreening.id.desc())
+        .limit(1)
+        .scalar_subquery()
+    ).label("nrs_data")
+
+    # campo1 — mNUTRIC score fields from latest MNUTRIC screening row
+    mnutric_data_subq = (
+        db.session.query(
+            func.json_build_object(
+                "mn_total", NutritionalScreening.mn_total,
+                "mn_idade", NutritionalScreening.mn_idade,
+                "mn_apache", NutritionalScreening.mn_apache,
+                "mn_sofa", NutritionalScreening.mn_sofa,
+                "mn_comor", NutritionalScreening.mn_comor,
+                "mn_dias", NutritionalScreening.mn_dias,
+                "mn_apache_manual", NutritionalScreening.mn_apache_manual,
+                "mn_sofa_manual", NutritionalScreening.mn_sofa_manual,
+            )
+        )
+        .filter(NutritionalScreening.nratendimento == Patient.admissionNumber)
+        .filter(NutritionalScreening.protocolo == "MNUTRIC")
+        .correlate(Patient)
+        .order_by(NutritionalScreening.id.desc())
+        .limit(1)
+        .scalar_subquery()
+    ).label("mnutric_data")
+
     query = (
         db.session.query(
             Patient.admissionNumber.label("id"),
@@ -107,18 +147,20 @@ def get_patients(setor=None, ala=None):
             glim_diag_subq,
             glim_fen_subq,
             glim_etiol_subq,
+            nrs_data_subq,
+            mnutric_data_subq,
         )
         .select_from(Patient)
-        .join(
+        .outerjoin(
             SegmentDepartment,
             (SegmentDepartment.idDepartment == Patient.idDepartment)
             & (SegmentDepartment.idHospital == Patient.idHospital),
         )
-        .join(
+        .outerjoin(
             Segment,
             Segment.id == SegmentDepartment.id,
         )
-        .join(
+        .outerjoin(
             Department,
             (Department.id == Patient.idDepartment)
             & (Department.idHospital == Patient.idHospital),

--- a/routes/nutritional/nutritional_job.py
+++ b/routes/nutritional/nutritional_job.py
@@ -9,7 +9,7 @@ which already raises AuthorizationError in production via api_endpoint_decorator
 
 import logging
 
-from flask import Blueprint
+from flask import Blueprint, current_app
 
 from decorators.api_endpoint_decorator import api_endpoint
 from services.nutritional import nutritional_job_service
@@ -22,9 +22,9 @@ app_nutritional_job = Blueprint("app_nutritional_job", __name__)
 @app_nutritional_job.route("/nutritional/job/run", methods=["POST"])
 @api_endpoint(is_admin=True)
 def run_job():
-    """Trigger the nutritional score recalculation job immediately."""
+    """Trigger the nutritional score recalculation job immediately (all schemas)."""
     logger.info("[US-BE-06] Disparo manual do job solicitado via endpoint.")
-    nutritional_job_service.recalculate_nutritional_scores()
+    nutritional_job_service.recalculate_nutritional_scores(current_app._get_current_object())
     logger.info("[US-BE-06] Disparo manual concluido.")
     return {"message": "Job executado. Verifique os logs."}
 
@@ -32,17 +32,13 @@ def run_job():
 @app_nutritional_job.route("/nutritional/job/status", methods=["GET"])
 @api_endpoint(is_admin=True)
 def job_status():
-    """Return the current scheduler status and next run time."""
-    scheduler = nutritional_job_service.scheduler
-    job = scheduler.get_job("nutritional_score_recalc")
-
-    if not scheduler.running:
-        return {"scheduler": "stopped", "job": None}
-
+    """Return whether the background recalculation thread is alive."""
+    import threading
+    thread = next(
+        (t for t in threading.enumerate() if t.name == "nutritional-recalc"),
+        None,
+    )
     return {
-        "scheduler": "running",
-        "job": {
-            "id": job.id if job else None,
-            "next_run": job.next_run_time.isoformat() if job and job.next_run_time else None,
-        },
+        "scheduler": "running" if thread and thread.is_alive() else "stopped",
+        "thread": thread.name if thread else None,
     }

--- a/services/nutritional/nrs_nut_service.py
+++ b/services/nutritional/nrs_nut_service.py
@@ -119,14 +119,6 @@ def update_nrs_nut(nratendimento, request_data, user_context: User):
         triagem.protocolo = "MNUTRIC"
         db.session.add(triagem)
 
-    triagem.mn_apache = request_data.apache_ii
-    triagem.mn_sofa = request_data.sofa
-    triagem.mn_apache_manual = True
-    triagem.mn_sofa_manual = True
-    triagem.dados_incompletos = False
-    triagem.updated_at = now
-    triagem.updated_by = user_context.id
-
     age = _calculate_age(patient.birthdate)
     dias = _calculate_days(patient.admissionDate)
 
@@ -135,6 +127,13 @@ def update_nrs_nut(nratendimento, request_data, user_context: User):
     mn_sofa = _mnutric_score_sofa(request_data.sofa)
     mn_comor = _mnutric_score_comor(patient.id_icd)
     mn_dias = _mnutric_score_dias(dias)
+
+    triagem.mn_apache = mn_apache
+    triagem.mn_sofa = mn_sofa
+    triagem.mn_apache_manual = True
+    triagem.mn_sofa_manual = True
+    triagem.updated_at = now
+    triagem.updated_by = user_context.id
 
     mnutric_total = mn_idade + mn_apache + mn_sofa + mn_comor + mn_dias
     triagem.mnutric_total = mnutric_total
@@ -184,13 +183,19 @@ def update_nrs_nut(nratendimento, request_data, user_context: User):
 
 
 def _get_segment_type(nratendimento):
+    schema = (
+        db.session.connection()
+        .get_execution_options()
+        .get("schema_translate_map", {})
+        .get(None) or "demo"
+    )
     result = db.session.execute(
         text(
-            """
+            f"""
             SELECT seg.tp_segmento
-            FROM pessoa p
-            JOIN segmentosetor ss ON ss.fksetor = p.fksetor
-            JOIN segmento seg ON seg.idsegmento = ss.idsegmento
+            FROM "{schema}".pessoa p
+            JOIN "{schema}".segmentosetor ss ON ss.fksetor = p.fksetor
+            JOIN "{schema}".segmento seg ON seg.idsegmento = ss.idsegmento
             WHERE p.nratendimento = :nratendimento
             LIMIT 1
             """

--- a/services/nutritional/nutritional_active_patients_service.py
+++ b/services/nutritional/nutritional_active_patients_service.py
@@ -91,7 +91,7 @@ def get_patients(request_data: NutritionalPatientsRequest):
                 "npo": None,  # from demo.presmed - not implemented in this US
                 "alergia": None,  # from demo.pessoa - not implemented in this US
                 "al_ok": True,  # default: true when alergia is null
-                "campo1": None,  # null in this US (populated in US-BE-07)
+                "campo1": _build_campo1(protocolo, row),
                 "glim_diag": glim_diag,
                 "glim_fen": glim_fen,
                 "glim_etiol": glim_etiol,
@@ -145,4 +145,67 @@ def _calculate_imc(peso, altura):
     if peso and altura and altura > 0:
         altura_m = altura / 100.0
         return round(peso / (altura_m**2), 1)
+    return None
+
+
+def _build_campo1(protocolo, row):
+    """Build campo1 dict from the latest screening scores.
+
+    Returns None if no score has been calculated yet for this admission.
+    For MNUTRIC patients, NRS scores are included when available.
+    """
+    nrs = row.nrs_data or {}
+    mn = row.mnutric_data or {}
+
+    if protocolo == "NRS2002":
+        if not nrs or nrs.get("nrs_total") is None:
+            return None
+        return {
+            "nrs_total": nrs["nrs_total"],
+            "nrs_dims": {
+                "nut": nrs.get("nrs_nut") or 0,
+                "doenca": nrs.get("nrs_doenca") or 0,
+                "idade": nrs.get("nrs_idade") or 0,
+            },
+        }
+
+    if protocolo == "MNUTRIC":
+        if not mn:
+            return None
+
+        apache_manual = mn.get("mn_apache_manual") or False
+        sofa_manual = mn.get("mn_sofa_manual") or False
+        dados_incompletos = not apache_manual or not sofa_manual
+
+        if dados_incompletos:
+            return {
+                "dados_incompletos": True,
+                "mn_dims": {
+                    "idade": mn.get("mn_idade") or 0,
+                    "apache": None,
+                    "sofa": None,
+                    "comor": mn.get("mn_comor") or 0,
+                    "dias": mn.get("mn_dias") or 0,
+                },
+            }
+
+        result = {
+            "mnutric_total": mn["mn_total"],
+            "mn_dims": {
+                "idade": mn.get("mn_idade") or 0,
+                "apache": mn.get("mn_apache") or 0,
+                "sofa": mn.get("mn_sofa") or 0,
+                "comor": mn.get("mn_comor") or 0,
+                "dias": mn.get("mn_dias") or 0,
+            },
+        }
+        if nrs and nrs.get("nrs_total") is not None:
+            result["nrs_total"] = nrs["nrs_total"]
+            result["nrs_dims"] = {
+                "nut": nrs.get("nrs_nut") or 0,
+                "doenca": nrs.get("nrs_doenca") or 0,
+                "idade": nrs.get("nrs_idade") or 0,
+            }
+        return result
+
     return None

--- a/services/nutritional/nutritional_job_service.py
+++ b/services/nutritional/nutritional_job_service.py
@@ -1,89 +1,174 @@
 """Nutritional job service — US-BE-06.
 
 Periodic recalculation of Campo 1 scores (NRS-2002 and mNUTRIC) for all
-active admissions. Scheduled via APScheduler with a configurable interval
-(default: 15 minutes).
+active admissions across every active tenant schema.
 
-Dependencies: US-BE-04 (NRS engine) and US-BE-05 (mNUTRIC engine) must be
-implemented before this job can perform actual score updates.
+Runs outside the JWT request context: schema is set manually via
+dbSession.setSchema() before each database operation, and re-set after
+every commit/rollback (SQLAlchemy releases the connection on transaction end).
 """
 
-import atexit
 import logging
 import os
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import TimeoutError as FuturesTimeoutError
-
-from apscheduler.schedulers.background import BackgroundScheduler
+import threading
+import time
+from types import SimpleNamespace
 
 from config import Config
-from models.main import db
+from models.main import User, db, dbSession
 from repository.nutritional import nutritional_repository
-from services.nutritional import nutritional_patient_service
+from repository.nutritional.nutritional_nrs_repository import get_patient_department
+from services.nutritional import nutritional_nrs_service, nutritional_patient_service
+from services.nutritional.nutritional_nrs_service import is_uti_wrapper
 
 logger = logging.getLogger("noharm.nutritional")
 
-scheduler = BackgroundScheduler()
 
+def _get_active_schemas() -> list:
+    """Return all distinct schemas with at least one active user.
 
-def recalculate_nutritional_scores():
-    """Recalculate Campo 1 scores for all active admissions.
-
-    Processes each active admission independently so that an error in one
-    patient does not interrupt the rest of the batch. Logs total processed
-    count and error count at the end of each run.
+    Queries public.usuario — always accessible without schema_translate_map
+    because User.__table_args__ has schema='public'.
     """
-    logger.info("Iniciando recalculo de scores nutricionais...")
-    patients = nutritional_repository.get_active_admissions()
+    rows = (
+        db.session.query(User.schema)
+        .filter(User.active == True)
+        .distinct()
+        .all()
+    )
+    return [r[0] for r in rows]
+
+
+def _recalculate_schema(schema: str) -> tuple:
+    """Recalculate Campo 1 for all active admissions in a single tenant schema.
+
+    Sets schema_translate_map + search_path before each operation so that
+    both ORM queries (is_uti, recalculate_nrs) and raw SQL (get_active_admissions)
+    resolve to the correct tenant tables.
+
+    Returns (processed, errors) counts.
+    """
+    logger.info("Iniciando recalculo schema=%s", schema)
+
+    dbSession.setSchema(schema)
+    patients = nutritional_repository.get_active_admissions(schema=schema)
     processed, errors = 0, 0
 
     for patient in patients:
+        # Re-set after every commit/rollback — SQLAlchemy releases the connection
+        # that held schema_translate_map on transaction end.
+        dbSession.setSchema(schema)
         try:
-            if patient.is_icu:
-                result = nutritional_patient_service.recalculate_mnutric(patient)
+            patient_is_icu = is_uti_wrapper(
+                patient.nratendimento,
+                get_patient_segment_type_fn=lambda _: patient.tp_segmento,
+                get_patient_department_fn=get_patient_department,
+            )
+            patient_ns = SimpleNamespace(
+                admissionNumber=patient.nratendimento,
+                birthdate=patient.dtnascimento,
+                id_icd=patient.idcid or "",
+            )
 
+            if patient_is_icu:
+                result = nutritional_patient_service.recalculate_mnutric(patient)
                 if result is None:
                     logger.error(
-                        "Falha ao recalcular mNUTRIC para nratendimento=%s: retorno None",
+                        "Falha mNUTRIC nratendimento=%s schema=%s: retorno None",
                         patient.nratendimento,
+                        schema,
                     )
                     errors += 1
                     continue
-
                 logger.info(
-                    "mNUTRIC recalculado com sucesso para nratendimento=%s",
+                    "mNUTRIC recalculado nratendimento=%s schema=%s",
                     patient.nratendimento,
+                    schema,
                 )
-            else:
-                # TODO (US-BE-04): nutritional_score_service.recalculate_nrs(patient)
-                pass
+
+            nutritional_nrs_service.recalculate_nrs(patient_ns)
+            logger.info(
+                "NRS-2002 recalculado nratendimento=%s schema=%s",
+                patient.nratendimento,
+                schema,
+            )
 
             db.session.commit()
             processed += 1
         except Exception as e:
             db.session.rollback()
             logger.error(
-                "Erro ao recalcular nratendimento=%s: %s",
+                "Erro nratendimento=%s schema=%s: %s",
                 patient.nratendimento,
+                schema,
                 e,
                 exc_info=True,
             )
             errors += 1
 
     logger.info(
-        "Recalculo concluido. Processados: %d, Erros: %d", processed, errors
+        "schema=%s concluido. Processados: %d, Erros: %d",
+        schema,
+        processed,
+        errors,
     )
+    return processed, errors
 
 
-def init_scheduler(app):
-    """Register and start the scheduler bound to the Flask app context.
+def recalculate_nutritional_scores(app):
+    """Recalculate Campo 1 scores for every active tenant schema.
+
+    Called by the background thread and by the manual trigger endpoint
+    POST /nutritional/job/run. Pushes its own app context so it can run
+    inside a thread that does not inherit the caller's context.
+
+    Args:
+        app: Flask application instance.
+    """
+    with app.app_context():
+        schemas = _get_active_schemas()
+        logger.info(
+            "Iniciando recalculo nutricional: %d schema(s) encontrado(s): %s",
+            len(schemas),
+            schemas,
+        )
+
+        total_processed, total_errors = 0, 0
+        for schema in schemas:
+            try:
+                processed, errors = _recalculate_schema(schema)
+                total_processed += processed
+                total_errors += errors
+            except Exception as e:
+                logger.error(
+                    "Erro inesperado no schema=%s: %s", schema, e, exc_info=True
+                )
+
+        logger.info(
+            "Recalculo concluido. Total processados: %d, Total erros: %d",
+            total_processed,
+            total_errors,
+        )
+
+
+def _scheduler_loop(app, interval_seconds: int) -> None:
+    while True:
+        time.sleep(interval_seconds)
+        try:
+            recalculate_nutritional_scores(app)
+        except Exception:
+            logger.exception("[US-BE-06] Falha inesperada no ciclo do job.")
+
+
+def init_scheduler(app) -> None:
+    """Start the background recalculation thread bound to the Flask app.
 
     Should be called once from the app factory. Reads SCHEDULER_ENABLED and
     SCHEDULER_INTERVAL_MINUTES from Config to allow disabling the job in
     test/CI environments.
 
     Guards against Werkzeug's development reloader, which spawns two processes:
-    only the child process (WERKZEUG_RUN_MAIN=true) starts the scheduler.
+    only the child process (WERKZEUG_RUN_MAIN=true) starts the thread.
 
     Args:
         app: Flask application instance (needed for app context inside the job)
@@ -92,37 +177,20 @@ def init_scheduler(app):
         logger.info("Scheduler desabilitado (SCHEDULER_ENABLED=false).")
         return
 
-    # Werkzeug reloader guard: avoid starting two schedulers in development
     if app.debug and os.environ.get("WERKZEUG_RUN_MAIN") != "true":
         return
 
-    interval_minutes = Config.SCHEDULER_INTERVAL_MINUTES
+    interval_seconds = Config.SCHEDULER_INTERVAL_MINUTES * 60
 
-    timeout_seconds = Config.SCHEDULER_JOB_TIMEOUT_SECONDS
-
-    def _job_with_context():
-        with app.app_context():
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(recalculate_nutritional_scores)
-                try:
-                    future.result(timeout=timeout_seconds)
-                except FuturesTimeoutError:
-                    logger.error(
-                        "[US-BE-06] Job excedeu timeout de %ds e foi interrompido.",
-                        timeout_seconds,
-                    )
-
-    scheduler.add_job(
-        _job_with_context,
-        trigger="interval",
-        minutes=interval_minutes,
-        id="nutritional_score_recalc",
-        replace_existing=True,
+    t = threading.Thread(
+        target=_scheduler_loop,
+        args=(app, interval_seconds),
+        daemon=True,
+        name="nutritional-recalc",
     )
-    scheduler.start()
-    atexit.register(lambda: scheduler.running and scheduler.shutdown(wait=False))
+    t.start()
 
     logger.info(
-        "Scheduler iniciado. Job nutritional_score_recalc a cada %d min.",
-        interval_minutes,
+        "Scheduler iniciado (thread daemon). Recalculo a cada %d min.",
+        Config.SCHEDULER_INTERVAL_MINUTES,
     )

--- a/services/nutritional/nutritional_patient_service.py
+++ b/services/nutritional/nutritional_patient_service.py
@@ -28,16 +28,20 @@ def save_manual_mnutric(admission_number: int, mnutric: dict):
     )
 
 def calculate_mnutric(patient, apache, sofa) -> dict:
-    today             = datetime.now()
-    uti_days          = (today.date() - patient.utiEntryDate.date()).days
-    dados_incompletos = (apache is None) or (sofa is None)
+    """Calcula e persiste mNUTRIC a partir de entrada manual (PUT /mnutric-manual).
+
+    apache e sofa são os valores brutos informados pelo nutricionista.
+    Seta mn_apache_manual=True e mn_sofa_manual=True via save_manual_mnutric.
+    """
+    today        = datetime.now()
+    uti_days     = (today.date() - patient.utiEntryDate.date()).days
 
     mnutric_age       = _mnutric_age(patient.birthdate)
-    mnutric_apache    = _mnutric_apache_ii(apache) if apache is not None else 0
-    mnutric_sofa      = _mnutric_sofa(sofa) if sofa is not None else 0
+    mnutric_apache    = _mnutric_apache_ii(apache)
+    mnutric_sofa      = _mnutric_sofa(sofa)
     mnutric_comorbity = _mnutric_comorbity(patient.id_icd)
     mnutric_days_uti  = _mnutric_days_uti(uti_days)
-    mnutric           = (mnutric_age + mnutric_apache + mnutric_sofa + mnutric_comorbity + mnutric_days_uti)
+    mnutric           = mnutric_age + mnutric_apache + mnutric_sofa + mnutric_comorbity + mnutric_days_uti
 
     result = {
         "total"            : mnutric,
@@ -46,8 +50,8 @@ def calculate_mnutric(patient, apache, sofa) -> dict:
         "sofa"             : mnutric_sofa,
         "comorbity"        : mnutric_comorbity,
         "daysUTI"          : mnutric_days_uti,
-        "classify"         : _mnutric_clasify(mnutric) if not dados_incompletos else None,
-        "dados_incompletos": dados_incompletos,
+        "classify"         : _mnutric_clasify(mnutric),
+        "dados_incompletos": False,
     }
 
     if getattr(patient, "admissionNumber", None) is not None:
@@ -117,6 +121,12 @@ def _mnutric_clasify(mnutric: int) -> str:
         return "unknown"
 
 def recalculate_mnutric(patient):
+    """Recalculo periódico pelo job — preserva flags manuais de APACHE/SOFA.
+
+    dados_incompletos é derivado dos flags mn_apache_manual/mn_sofa_manual:
+    se o nutricionista ainda não inseriu os valores via PUT, o reconhecimento
+    permanece bloqueado no frontend.
+    """
     admission_number = getattr(patient, "nratendimento", None)
     birthdate = getattr(patient, "dtnascimento", None)
     admission_date = getattr(patient, "dtinternacao", None)
@@ -137,10 +147,33 @@ def recalculate_mnutric(patient):
     )
 
     screening = nutritional_repository.get_saved_mnutric(admission_number)
-    apache = _restore_apache_ii_from_dimension(getattr(screening, "mn_apache", None))
-    sofa = _restore_sofa_from_dimension(getattr(screening, "mn_sofa", None))
+    apache_manual = getattr(screening, "mn_apache_manual", False) or False
+    sofa_manual = getattr(screening, "mn_sofa_manual", False) or False
+    dados_incompletos = not apache_manual or not sofa_manual
 
-    result = calculate_mnutric(patient=normalized, apache=apache, sofa=sofa)
+    apache = _restore_apache_ii_from_dimension(getattr(screening, "mn_apache", None)) if apache_manual else None
+    sofa = _restore_sofa_from_dimension(getattr(screening, "mn_sofa", None)) if sofa_manual else None
+
+    today = datetime.now()
+    uti_entry = normalized.utiEntryDate
+    uti_days = (today.date() - uti_entry.date()).days if uti_entry else 0
+
+    result = {
+        "age":          _mnutric_age(normalized.birthdate),
+        "apache":       _mnutric_apache_ii(apache) if apache is not None else None,
+        "sofa":         _mnutric_sofa(sofa) if sofa is not None else None,
+        "comorbity":    _mnutric_comorbity(normalized.id_icd),
+        "daysUTI":      _mnutric_days_uti(uti_days),
+        "dados_incompletos": dados_incompletos,
+        "total":        None,
+        "classify":     None,
+    }
+
+    if not dados_incompletos:
+        result["total"] = sum(v for v in [result["age"], result["apache"], result["sofa"], result["comorbity"], result["daysUTI"]] if v is not None)
+        result["classify"] = _mnutric_clasify(result["total"])
+
+    nutritional_repository.update_mnutric_scores(admission_number, result)
 
     logging.info(
         "mNUTRIC recalculado para nratendimento=%s: total=%s, classify=%s, dados_incompletos=%s",


### PR DESCRIPTION
## Resumo

Correções no motor nutricional NITRA cobrindo os itens identificados nas user stories US-BE-05, US-BE-06 e US-BE-07.

## Alterações

### `dados_incompletos` — lógica de flags manuais (US-BE-05)
- `dados_incompletos` derivado de `mn_apache_manual`/`mn_sofa_manual`, não de null check
- `save_manual_mnutric`: único setter dos flags (caminho PUT `/mnutric-manual`)
- `update_mnutric_scores` (novo): caminho exclusivo do job — preserva flags, só atualiza totais quando ambos flags são `true`
- `campo1` agora expõe `dados_incompletos: true` com dims parciais quando apache/sofa não informados; antes retornava `null`

### Job de recálculo periódico (US-BE-06)
- APScheduler removido → `threading.Thread` daemon sem dependência externa
- Intervalo configurável via `SCHEDULER_INTERVAL_MINUTES`
- Job recalcula mNUTRIC + NRS para pacientes UTI; NRS para não-UTI
- Schema re-aplicado a cada iteração (SQLAlchemy libera conexão no commit/rollback)
- `_get_active_schemas`: busca schemas ativos em `public.usuario`

### Listagem de pacientes — `GET /nutritional/patients` (US-BE-07)
- `ala`: corrigido de `literal("Enfermaria")` hardcoded para `Segment.description`
- `JOIN` → `OUTERJOIN` em `SegmentDepartment`, `Segment`, `Department` — pacientes sem mapeamento aparecem
- Subqueries ordenadas por `id DESC` (evita comportamento indefinido com `created_at` null)
- Adicionadas subqueries `nrs_data` e `mnutric_data` com `mn_apache_manual`/`mn_sofa_manual`

### Fixes pontuais
- `nrs_nut_service`: salvava valor bruto (ex: 60) em `mn_apache` violando `CHECK (0–3)` — corrigido para score dimensional
- `_get_segment_type`: raw SQL agora usa schema dinâmico via `schema_translate_map` (fix `relation "pessoa" does not exist`)
- `get_active_admissions`: multi-tenant via `SET LOCAL search_path`, removido default hardcoded `schema="demo"`
- `api_endpoint_decorator`: guarda `is_admin` antes de checar `permission_test_count` (fix 403 em rotas admin)
- `logging_config`: logger `noharm.nutritional` registrado em INFO em todos os ambientes

## Checklist

- [x] Testado localmente com Docker (db-init + API)
- [x] Job periódico validado (3 min interval, thread daemon)
- [x] Pacientes UTI com `dados_incompletos=true` visíveis no frontend
- [x] PUT `/mnutric-manual` seta flags e retorna `dados_incompletos: false`
- [x] PUT `/nrs-nut` corrigido (score dimensional, schema dinâmico)
- [x] Ala B/C retornam nome correto do setor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Nutritional scoring recalculation now operates across all active tenant schemas.
  * Patient listings now include NRS2002 and MNUTRIC score data as JSON fields.

* **Bug Fixes**
  * Improved admin permission handling in API endpoint access control.
  * Enhanced handling of incomplete nutritional screening data and manual score overrides.

* **Chores**
  * Updated Docker Compose database volume configuration.
  * Migrated background nutritional job scheduling to daemon threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->