### PR TITLE
US-BE | Fix da engine NRS-2002: classificacao e UTI no job

### DIFF
--- a/repository/nutritional/nutritional_nrs_repository.py
+++ b/repository/nutritional/nutritional_nrs_repository.py
@@ -80,6 +80,7 @@ def _update_triagem(
     triagem.nrs_doenca = nrs_score.nrs_doenca
     triagem.nrs_idade = nrs_score.nrs_idade
     triagem.nrs_total = nrs_score.nrs_total
+    triagem.classificacao = nrs_score.classificacao
     triagem.nrs_completo = nrs_score.nrs_completo
     triagem.nrs_ref_at = nrs_score.nrs_ref_at
     triagem.calculado_at = nrs_score.calculado_at

--- a/services/nutritional/nutritional_dtos.py
+++ b/services/nutritional/nutritional_dtos.py
@@ -10,6 +10,7 @@ class NrsScoreDTO:
     nrs_doenca: int
     nrs_idade: int
     nrs_total: int
+    classificacao: str
     nrs_completo: bool
     nrs_ref_at: datetime
     calculado_at: datetime

--- a/services/nutritional/nutritional_job_service.py
+++ b/services/nutritional/nutritional_job_service.py
@@ -86,7 +86,7 @@ def _recalculate_schema(schema: str) -> tuple:
                     schema,
                 )
 
-            nutritional_nrs_service.recalculate_nrs(patient_ns)
+            nutritional_nrs_service.recalculate_nrs(patient_ns, is_icu=patient_is_icu)
             logger.info(
                 "NRS-2002 recalculado nratendimento=%s schema=%s",
                 patient.nratendimento,

--- a/services/nutritional/nutritional_nrs_service.py
+++ b/services/nutritional/nutritional_nrs_service.py
@@ -92,17 +92,26 @@ def is_uti(nratendimento: int) -> bool:
     )
 
 
-def score_nrs_component_b(nratendimento: int, cid: str) -> int:
-    return _score_nrs_component_b(nratendimento, cid, is_uti, get_cid_mappings_cached)
+def classify_nrs_score(nrs_total: int) -> str:
+    if nrs_total >= 5:
+        return "cr"
+    if nrs_total >= 3:
+        return "al"
+    if nrs_total >= 1:
+        return "md"
+    return "bx"
+
+
+def score_nrs_component_b(is_icu: bool, cid: str) -> int:
+    return _score_nrs_component_b(is_icu, cid, get_cid_mappings_cached)
 
 
 def _score_nrs_component_b(
-    nratendimento: int,
+    is_icu: bool,
     cid: str,
-    is_uti_fn: Callable[[int], bool],
     get_cid_mappings_cached_fn: Callable[[], CidMappings],
 ) -> int:
-    if is_uti_fn(nratendimento):
+    if is_icu:
         return 3
     if not cid:
         return 0
@@ -116,19 +125,22 @@ def _score_nrs_component_b(
     chapter = cid[0].upper()
     return mappings.chapters.get(chapter, 0)
 
+
 def calculate_age(dt_nascimento: datetime) -> int:
     hoje = datetime.today()
     return hoje.year - dt_nascimento.year - (
         (hoje.month, hoje.day) < (dt_nascimento.month, dt_nascimento.day)
     )
 
+
 def build_nrs_update(
     patient: Patient,
     triagem: NutritionalScreening,
     nrs_row: Optional[NutritionalNrs],
+    is_icu: bool,
     *,
     score_nrs_component_a_fn: Callable[[Optional[Any]], Optional[int]],
-    score_nrs_component_b_fn: Callable[[int, str], int],
+    score_nrs_component_b_fn: Callable[[bool, str], int],
     calc_age_fn: Callable[[datetime], int],
     now_fn: Callable[[], datetime]
 ) -> NrsScoreDTO:
@@ -140,16 +152,18 @@ def build_nrs_update(
     else:
         comp_a = None
         nrs_ref_at = triagem.nrs_ref_at
-    comp_b: int = score_nrs_component_b_fn(patient.admissionNumber, patient.id_icd)
+    comp_b: int = score_nrs_component_b_fn(is_icu, patient.id_icd)
     comp_c: int = 1 if calc_age_fn(patient.birthdate) >= 70 else 0
     completo: bool = comp_a is not None
     total: int = (comp_a or 0) + comp_b + comp_c
+    classificacao: str = classify_nrs_score(total)
     return NrsScoreDTO(
         id=triagem.id,
         nrs_nut=comp_a,
         nrs_doenca=comp_b,
         nrs_idade=comp_c,
         nrs_total=total,
+        classificacao=classificacao,
         nrs_completo=completo,
         nrs_ref_at=nrs_ref_at,
         calculado_at=now_fn(),
@@ -158,6 +172,7 @@ def build_nrs_update(
 
 def __recalculate_nrs(
     patient: Patient,
+    is_icu: bool,
     *,
     get_or_create_triagem_fn: Callable[[int], Any] = get_or_create_triagem,
     nutritional_nrs_repo_fn: Callable[
@@ -167,7 +182,7 @@ def __recalculate_nrs(
     score_nrs_component_a_fn: Callable[
         [Optional[NutritionalNrs]], Optional[int]
     ] = score_nrs_component_a,
-    score_nrs_component_b_fn: Callable[[int, str], int] = score_nrs_component_b,
+    score_nrs_component_b_fn: Callable[[bool, str], int] = score_nrs_component_b,
     calc_age_fn: Callable[[datetime], int] = calculate_age,
     now_fn: Callable[[], datetime] = datetime.now
 ) -> None:
@@ -177,6 +192,7 @@ def __recalculate_nrs(
         patient,
         triagem,
         nrs_row,
+        is_icu,
         score_nrs_component_a_fn=score_nrs_component_a_fn,
         score_nrs_component_b_fn=score_nrs_component_b_fn,
         calc_age_fn=calc_age_fn,
@@ -189,6 +205,6 @@ def __recalculate_nrs(
     return None
 
 
-def recalculate_nrs(patient: Patient) -> None:
-    __recalculate_nrs(patient)
+def recalculate_nrs(patient: Patient, is_icu: bool) -> None:
+    __recalculate_nrs(patient, is_icu)
     return None

--- a/tests/unit/test_nutritional_job_service.py
+++ b/tests/unit/test_nutritional_job_service.py
@@ -62,6 +62,8 @@ class TestRecalculateNutritionalScores:
         assert mock_nrs.call_count == 2       # ambos os pacientes passam por NRS
         assert mock_mnutric.call_count == 1   # apenas paciente ICU passa por mNUTRIC
         assert mock_commit.call_count == 2    # commit por paciente processado com sucesso
+        for call_item, patient in zip(mock_nrs.call_args_list, patients, strict=True):
+            assert call_item.kwargs.get("is_icu") == patient.is_icu
 
     def test_tolerates_single_patient_failure(self):
         """An exception on one patient must not interrupt the rest of the batch."""

--- a/tests/unit/test_nutritional_nrs_repository.py
+++ b/tests/unit/test_nutritional_nrs_repository.py
@@ -127,6 +127,7 @@ def test_update_triagem_internal_updates_fields_and_flushes() -> None:
         nrs_doenca=None,
         nrs_idade=None,
         nrs_total=None,
+        classificacao=None,
         nrs_completo=False,
         nrs_ref_at=None,
         calculado_at=None,
@@ -138,6 +139,7 @@ def test_update_triagem_internal_updates_fields_and_flushes() -> None:
         nrs_doenca=1,
         nrs_idade=1,
         nrs_total=4,
+        classificacao="al",
         nrs_completo=True,
         nrs_ref_at=now,
         calculado_at=now,
@@ -150,6 +152,7 @@ def test_update_triagem_internal_updates_fields_and_flushes() -> None:
     assert triagem.nrs_doenca == 1
     assert triagem.nrs_idade == 1
     assert triagem.nrs_total == 4
+    assert triagem.classificacao == "al"
     assert triagem.nrs_completo is True
     assert triagem.nrs_ref_at == now
     assert triagem.calculado_at == now

--- a/tests/unit/test_nutritional_nrs_service.py
+++ b/tests/unit/test_nutritional_nrs_service.py
@@ -193,57 +193,52 @@ def test_score_nrs_component_b_delegates_to_internal(monkeypatch: pytest.MonkeyP
     internal_mock = MagicMock(return_value=2)
     monkeypatch.setattr(svc, "_score_nrs_component_b", internal_mock)
 
-    result = svc.score_nrs_component_b(10, "A123")
+    result = svc.score_nrs_component_b(True, "A123")
 
     assert result == 2
-    internal_mock.assert_called_once_with(10, "A123", svc.is_uti, svc.get_cid_mappings_cached)
+    internal_mock.assert_called_once_with(True, "A123", svc.get_cid_mappings_cached)
 
 
 # 7) _score_nrs_component_b
 
 def test_internal_component_b_returns_3_for_icu() -> None:
-    is_uti_fn = MagicMock(return_value=True)
     get_mappings_fn = MagicMock()
 
-    result = svc._score_nrs_component_b(1, "A123", is_uti_fn, get_mappings_fn)
+    result = svc._score_nrs_component_b(True, "A123", get_mappings_fn)
 
     assert result == 3
     get_mappings_fn.assert_not_called()
 
 
 def test_internal_component_b_returns_0_for_empty_cid() -> None:
-    is_uti_fn = MagicMock(return_value=False)
     get_mappings_fn = MagicMock()
 
-    result = svc._score_nrs_component_b(1, "", is_uti_fn, get_mappings_fn)
+    result = svc._score_nrs_component_b(False, "", get_mappings_fn)
 
     assert result == 0
     get_mappings_fn.assert_not_called()
 
 
 def test_internal_component_b_uses_prefix_override(cid_mappings: svc.CidMappings) -> None:
-    is_uti_fn = MagicMock(return_value=False)
     get_mappings_fn = MagicMock(return_value=cid_mappings)
 
-    result = svc._score_nrs_component_b(1, "A1299", is_uti_fn, get_mappings_fn)
+    result = svc._score_nrs_component_b(False, "A1299", get_mappings_fn)
 
     assert result == 2
 
 
 def test_internal_component_b_falls_back_to_chapter_score(cid_mappings: svc.CidMappings) -> None:
-    is_uti_fn = MagicMock(return_value=False)
     get_mappings_fn = MagicMock(return_value=cid_mappings)
 
-    result = svc._score_nrs_component_b(1, "C991", is_uti_fn, get_mappings_fn)
+    result = svc._score_nrs_component_b(False, "C991", get_mappings_fn)
 
     assert result == 0
 
 
 def test_internal_component_b_returns_zero_when_chapter_not_mapped() -> None:
-    is_uti_fn = MagicMock(return_value=False)
     get_mappings_fn = MagicMock(return_value=svc.CidMappings(overrides={}, chapters={}))
 
-    result = svc._score_nrs_component_b(1, "Z991", is_uti_fn, get_mappings_fn)
+    result = svc._score_nrs_component_b(False, "Z991", get_mappings_fn)
 
     assert result == 0
 
@@ -251,15 +246,31 @@ def test_internal_component_b_returns_zero_when_chapter_not_mapped() -> None:
 def test_internal_component_b_len_lt_3_uses_chapter_score(
     cid_mappings: svc.CidMappings,
 ) -> None:
-    is_uti_fn = MagicMock(return_value=False)
     get_mappings_fn = MagicMock(return_value=cid_mappings)
 
-    result = svc._score_nrs_component_b(1, "A", is_uti_fn, get_mappings_fn)
+    result = svc._score_nrs_component_b(False, "A", get_mappings_fn)
 
     assert result == 1
 
 
-# 8) calculate_age
+# 8) classify_nrs_score
+
+@pytest.mark.parametrize(
+    "total,expected",
+    [
+        (0, "bx"),
+        (1, "md"),
+        (2, "md"),
+        (3, "al"),
+        (4, "al"),
+        (5, "cr"),
+    ],
+)
+def test_classify_nrs_score_mapping(total: int, expected: str) -> None:
+    assert svc.classify_nrs_score(total) == expected
+
+
+# 9) calculate_age
 
 @pytest.mark.parametrize(
     "today,birthdate,expected_age",
@@ -303,6 +314,7 @@ def test_build_nrs_update_with_nrs_row_uses_row_timestamp(
         patient,
         triagem,
         nrs_row,
+        False,
         score_nrs_component_a_fn=score_a_fn,
         score_nrs_component_b_fn=score_b_fn,
         calc_age_fn=calc_age_fn,
@@ -314,11 +326,12 @@ def test_build_nrs_update_with_nrs_row_uses_row_timestamp(
     assert dto.nrs_doenca == 1
     assert dto.nrs_idade == 1
     assert dto.nrs_total == 4
+    assert dto.classificacao == "al"
     assert dto.nrs_completo is True
     assert dto.nrs_ref_at == nrs_row.updated_at
     assert dto.calculado_at == now
     score_a_fn.assert_called_once_with(nrs_row)
-    score_b_fn.assert_called_once_with(patient.admissionNumber, patient.id_icd)
+    score_b_fn.assert_called_once_with(False, patient.id_icd)
 
 
 def test_build_nrs_update_without_nrs_row_uses_triagem_ref(
@@ -335,6 +348,7 @@ def test_build_nrs_update_without_nrs_row_uses_triagem_ref(
         patient,
         triagem,
         None,
+        True,
         score_nrs_component_a_fn=score_a_fn,
         score_nrs_component_b_fn=score_b_fn,
         calc_age_fn=calc_age_fn,
@@ -346,6 +360,7 @@ def test_build_nrs_update_without_nrs_row_uses_triagem_ref(
     assert dto.nrs_doenca == 2
     assert dto.nrs_idade == 0
     assert dto.nrs_total == 2
+    assert dto.classificacao == "md"
     assert dto.nrs_completo is False
     assert dto.nrs_ref_at == triagem.nrs_ref_at
     assert dto.calculado_at == now
@@ -370,6 +385,7 @@ def test_recalculate_internal_calls_dependencies_and_updates(
 
     svc.__recalculate_nrs(
         patient,
+        False,
         get_or_create_triagem_fn=get_or_create_fn,
         nutritional_nrs_repo_fn=get_nrs_fn,
         updater_func=updater_fn,
@@ -406,6 +422,7 @@ def test_recalculate_internal_without_nrs_marks_incomplete(
 
     svc.__recalculate_nrs(
         patient,
+        True,
         get_or_create_triagem_fn=get_or_create_fn,
         nutritional_nrs_repo_fn=get_nrs_fn,
         updater_func=updater_fn,
@@ -428,17 +445,13 @@ def test_recalculate_nrs_delegates_to_internal(monkeypatch: pytest.MonkeyPatch, 
     internal_mock = MagicMock(return_value=None)
     monkeypatch.setattr(svc, "__recalculate_nrs", internal_mock)
 
-    result = svc.recalculate_nrs(patient)
+    result = svc.recalculate_nrs(patient, True)
 
     assert result is None
-    internal_mock.assert_called_once_with(patient)
+    internal_mock.assert_called_once_with(patient, True)
 
 
 # Casos de Teste Obrigatórios (matriz funcional de admissão)
-
-
-def _classificacao_por_total(nrs_total: int) -> str:
-    return "al" if nrs_total >= 3 else "bx"
 
 
 @pytest.mark.parametrize(
@@ -550,8 +563,9 @@ def test_casos_obrigatorios_nrs(
         patient,
         triagem,
         nrs_row,
+        comp_b == 3,
         score_nrs_component_a_fn=svc.score_nrs_component_a,
-        score_nrs_component_b_fn=lambda admission_number, cid: comp_b,
+        score_nrs_component_b_fn=lambda is_icu, cid: comp_b,
         calc_age_fn=lambda _: idade,
         now_fn=lambda: datetime(2026, 4, 11, 12, 0, 0),
     )
@@ -560,7 +574,7 @@ def test_casos_obrigatorios_nrs(
     assert dto.nrs_doenca == expected_b, cenario
     assert dto.nrs_idade == expected_c, cenario
     assert dto.nrs_total == expected_total, cenario
-    assert _classificacao_por_total(dto.nrs_total) == expected_classe, cenario
+    assert dto.classificacao == expected_classe, cenario
     assert dto.nrs_completo is expected_completo, cenario
 
 
@@ -598,21 +612,19 @@ def test_is_uti_helper_additional_negative_patterns(department: str) -> None:
 
 
 def test_internal_component_b_uses_uppercase_chapter_for_lowercase_cid() -> None:
-    is_uti_fn = MagicMock(return_value=False)
     mappings = svc.CidMappings(overrides={}, chapters={"A": 2})
     get_mappings_fn = MagicMock(return_value=mappings)
 
-    result = svc._score_nrs_component_b(1, "a991", is_uti_fn, get_mappings_fn)
+    result = svc._score_nrs_component_b(False, "a991", get_mappings_fn)
 
     assert result == 2
 
 
 def test_internal_component_b_prefers_override_over_chapter() -> None:
-    is_uti_fn = MagicMock(return_value=False)
     mappings = svc.CidMappings(overrides={"A12": 1}, chapters={"A": 3})
     get_mappings_fn = MagicMock(return_value=mappings)
 
-    result = svc._score_nrs_component_b(1, "A123", is_uti_fn, get_mappings_fn)
+    result = svc._score_nrs_component_b(False, "A123", get_mappings_fn)
 
     assert result == 1
 
@@ -630,8 +642,9 @@ def test_build_nrs_update_with_nrs_row_and_none_score_component_a() -> None:
         patient,
         triagem,
         nrs_row,
+        False,
         score_nrs_component_a_fn=lambda _row: None,
-        score_nrs_component_b_fn=lambda _adm, _cid: 2,
+        score_nrs_component_b_fn=lambda _is_icu, _cid: 2,
         calc_age_fn=lambda _birthdate: 80,
         now_fn=lambda: datetime(2026, 4, 11, 12, 0, 0),
     )
@@ -640,6 +653,7 @@ def test_build_nrs_update_with_nrs_row_and_none_score_component_a() -> None:
     assert dto.nrs_doenca == 2
     assert dto.nrs_idade == 1
     assert dto.nrs_total == 3
+    assert dto.classificacao == "al"
     assert dto.nrs_completo is False
     assert dto.nrs_ref_at == nrs_row.updated_at
 
@@ -660,11 +674,12 @@ def test_recalculate_internal_passes_nrs_row_to_component_a_function() -> None:
 
     svc.__recalculate_nrs(
         patient,
+        False,
         get_or_create_triagem_fn=get_or_create_fn,
         nutritional_nrs_repo_fn=get_nrs_fn,
         updater_func=updater_fn,
         score_nrs_component_a_fn=score_a_fn,
-        score_nrs_component_b_fn=lambda _adm, _cid: 0,
+        score_nrs_component_b_fn=lambda _is_icu, _cid: 0,
         calc_age_fn=lambda _birthdate: 50,
         now_fn=lambda: datetime(2026, 4, 11, 12, 0, 0),
     )


### PR DESCRIPTION
# US-BE | Fix da engine NRS-2002: classificação e UTI no job

## Resumo
Esta PR corrige a engine do NRS-2002 para persistir `nutricional_triagem.classificacao` conforme a regra de score, reaproveitar o status de UTI no job (`is_icu`) sem nova consulta ao banco e manter classificação mesmo quando `nrs_completo=false` (score parcial).

## O que foi feito
Foi adicionada a classificação no cálculo do NRS e ela passou a ser enviada no DTO e persistida na triagem. Além disso, o cálculo do componente B passou a aceitar `is_icu` diretamente e o job agora repassa esse valor, eliminando a busca redundante no banco. Os testes unitários foram ajustados para refletir a nova assinatura e validar a classificação e os casos obrigatórios definidos na issue.

Arquivos principais atualizados:
- `services/nutritional/nutritional_nrs_service.py`
- `services/nutritional/nutritional_dtos.py`
- `repository/nutritional/nutritional_nrs_repository.py`
- `services/nutritional/nutritional_job_service.py`
- `tests/unit/test_nutritional_nrs_service.py`
- `tests/unit/test_nutritional_nrs_repository.py`
- `tests/unit/test_nutritional_job_service.py`

## Critérios de aceite atendidos
Os critérios de aceite foram cobertos: `recalculate_nrs` recebe `is_icu` obrigatório e aplica em `comp_b`, `_recalculate_schema` repassa `patient_is_icu`, `classificacao` é persistida em `nutricional_triagem` conforme a regra e a classificação é calculada mesmo quando `nrs_completo=false`.

## Testes
Testes não executados. Sugestão:
- `make test-file FILE=tests/unit/test_nutritional_nrs_service.py`
- `make test-file FILE=tests/unit/test_nutritional_job_service.py`

## Risco
**Baixo**. Alterações isoladas na engine NRS e testes unitários atualizados.

## Checklist
Testes executados: [ ]

## Issue vinculada
US-BE - Fix da engine NRS-2002: classificação e UTI no job
