### PR TITLE
US-BE-13 | Ordenação de `pri` na listagem nutricional

### DIFF
--- a/repository/nutritional_patients_repository.py
+++ b/repository/nutritional_patients_repository.py
@@ -81,6 +81,28 @@ def get_patients(setor=None, ala=None):
         .scalar_subquery()
     ).label("sev")
 
+    # score total (NRS-2002)
+    nrs_total_subq = (
+        db.session.query(NutritionalScreening.nrs_total)
+        .filter(NutritionalScreening.nratendimento == Patient.admissionNumber)
+        .filter(NutritionalScreening.protocolo == "NRS2002")
+        .correlate(Patient)
+        .order_by(NutritionalScreening.id.desc())
+        .limit(1)
+        .scalar_subquery()
+    )
+
+    # score total (mNUTRIC)
+    mnutric_total_subq = (
+        db.session.query(NutritionalScreening.mn_total)
+        .filter(NutritionalScreening.nratendimento == Patient.admissionNumber)
+        .filter(NutritionalScreening.protocolo == "MNUTRIC")
+        .correlate(Patient)
+        .order_by(NutritionalScreening.id.desc())
+        .limit(1)
+        .scalar_subquery()
+    )
+
     # GLIM
     glim_diag_subq = (
         db.session.query(NutritionalGlim.diagnostico)
@@ -194,6 +216,27 @@ def get_patients(setor=None, ala=None):
         .filter(Patient.dischargeDate.is_(None))
     )
 
+    sev_order = case(
+        (sev_subq == literal("cr"), 1),
+        (sev_subq == literal("al"), 2),
+        (sev_subq == literal("md"), 3),
+        (sev_subq == literal("bx"), 4),
+        else_=5,
+    )
+
+    score_expr = case(
+        (
+            Segment.type == SegmentTypeEnum.ICU.value,
+            func.coalesce(mnutric_total_subq, nrs_total_subq),
+        ),
+        else_=nrs_total_subq,
+    )
+
+    is_icu_expr = case(
+        (Segment.type == SegmentTypeEnum.ICU.value, 1),
+        else_=0,
+    )
+
     # filtros
     if setor is not None:
         query = query.filter(Patient.idDepartment == setor)
@@ -214,4 +257,14 @@ def get_patients(setor=None, ala=None):
 
         else:
             query = query.filter(Segment.type.is_(None))
+
+    query = query.order_by(
+        sev_order,
+        score_expr.desc().nulls_last(),
+        d7_expr.desc(),
+        haval_expr.desc().nulls_last(),
+        is_icu_expr.desc(),
+        Patient.admissionDate.asc().nulls_last(),
+        Patient.admissionNumber.asc(),
+    )
     return query.all()

--- a/repository/nutritional_patients_repository.py
+++ b/repository/nutritional_patients_repository.py
@@ -66,11 +66,16 @@ def get_patients(setor=None, ala=None):
         )
         .subquery("last_assessment")
     )
-    # sev
+    # sev - filter by protocol based on segment type (ICU -> MNUTRIC, else NRS2002)
+    _sev_protocolo = case(
+        (Segment.type == SegmentTypeEnum.ICU.value, literal("MNUTRIC")),
+        else_=literal("NRS2002"),
+    )
     sev_subq = (
         db.session.query(NutritionalScreening.classificacao)
         .filter(NutritionalScreening.nratendimento == Patient.admissionNumber)
-        .correlate(Patient)
+        .filter(NutritionalScreening.protocolo == _sev_protocolo)
+        .correlate(Patient, Segment)
         .order_by(NutritionalScreening.id.desc())
         .limit(1)
         .scalar_subquery()

--- a/tests/unit/test_nutritional_patients_repository.py
+++ b/tests/unit/test_nutritional_patients_repository.py
@@ -4,9 +4,10 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from sqlalchemy import func, literal
+from sqlalchemy.sql.elements import Case
 
 from models.enums import SegmentTypeEnum
-from models.nutritional import NutritionalAssessment
+from models.nutritional import NutritionalAssessment, NutritionalScreening
 from models.prescription import Patient
 from models.segment import Segment
 from repository import nutritional_patients_repository as repo
@@ -67,6 +68,36 @@ def _setup_session(monkeypatch, rows):
     return mocked_session, main_query, last_assessment_query, last_assessment_subquery
 
 
+def _setup_session_with_sev_subq(monkeypatch, rows):
+    """Patch repo.db.session and return the sev subquery builder for inspection."""
+    main_query = _make_main_query(rows)
+    last_assessment_query, last_assessment_subquery = _make_last_assessment_builder()
+    sev_subq_builder = _make_subquery_builder(literal(None))
+
+    mocked_session = MagicMock()
+    mocked_session.query.side_effect = [
+        _make_subquery_builder(func.now()),  # haval_subq
+        _make_subquery_builder(literal(0)),  # d7_subq
+        last_assessment_query,  # last_assessment grouped subquery
+        sev_subq_builder,  # sev_subq
+        _make_subquery_builder(literal(None)),  # glim_diag_subq
+        _make_subquery_builder(literal(None)),  # glim_fen_subq
+        _make_subquery_builder(literal(None)),  # glim_etiol_subq
+        _make_subquery_builder(literal(None)),  # nrs_data_subq
+        _make_subquery_builder(literal(None)),  # mnutric_data_subq
+        main_query,
+    ]
+
+    monkeypatch.setattr(repo.db, "session", mocked_session)
+    return (
+        mocked_session,
+        main_query,
+        last_assessment_query,
+        last_assessment_subquery,
+        sev_subq_builder,
+    )
+
+
 def _get_filter(main_query, index):
     return main_query.filter.call_args_list[index].args[0]
 
@@ -112,6 +143,28 @@ def test_get_patients_builds_last_assessment_subquery(monkeypatch):
         NutritionalAssessment.frequencia,
     )
     last_assessment_query.subquery.assert_called_once_with("last_assessment")
+
+
+def test_get_patients_builds_sev_subq_with_protocol_filter(monkeypatch):
+    _, _, _, _, sev_subq_builder = _setup_session_with_sev_subq(
+        monkeypatch, rows=[]
+    )
+
+    repo.get_patients()
+
+    assert sev_subq_builder.filter.call_count == 2
+
+    protocolo_filter = sev_subq_builder.filter.call_args_list[1].args[0]
+    _assert_same_column(protocolo_filter.left, NutritionalScreening.protocolo)
+    assert isinstance(protocolo_filter.right, Case)
+
+    when_cond, when_result = protocolo_filter.right.whens[0]
+    _assert_same_column(when_cond.left, Segment.type)
+    assert when_cond.right.value == SegmentTypeEnum.ICU.value
+    assert when_result.value == "MNUTRIC"
+    assert protocolo_filter.right.else_.value == "NRS2002"
+
+    assert sev_subq_builder.correlate.call_args.args == (Patient, Segment)
 
 
 def test_get_patients_with_setor_applies_department_filter(monkeypatch):

--- a/tests/unit/test_nutritional_patients_repository.py
+++ b/tests/unit/test_nutritional_patients_repository.py
@@ -29,6 +29,7 @@ def _make_last_assessment_builder():
     grouped = MagicMock()
     grouped.distinct.return_value = grouped
     grouped.group_by.return_value = grouped
+    grouped.order_by.return_value = grouped
 
     subquery = MagicMock()
     grouped.subquery.return_value = subquery
@@ -41,6 +42,7 @@ def _make_main_query(rows):
     main_query.select_from.return_value = main_query
     main_query.outerjoin.return_value = main_query
     main_query.filter.return_value = main_query
+    main_query.order_by.return_value = main_query
     main_query.all.return_value = rows
     return main_query
 
@@ -56,6 +58,8 @@ def _setup_session(monkeypatch, rows):
         _make_subquery_builder(literal(0)),  # d7_subq
         last_assessment_query,  # last_assessment grouped subquery
         _make_subquery_builder(literal(None)),  # sev_subq
+        _make_subquery_builder(literal(None)),  # nrs_total_subq
+        _make_subquery_builder(literal(None)),  # mnutric_total_subq
         _make_subquery_builder(literal(None)),  # glim_diag_subq
         _make_subquery_builder(literal(None)),  # glim_fen_subq
         _make_subquery_builder(literal(None)),  # glim_etiol_subq
@@ -80,6 +84,8 @@ def _setup_session_with_sev_subq(monkeypatch, rows):
         _make_subquery_builder(literal(0)),  # d7_subq
         last_assessment_query,  # last_assessment grouped subquery
         sev_subq_builder,  # sev_subq
+        _make_subquery_builder(literal(None)),  # nrs_total_subq
+        _make_subquery_builder(literal(None)),  # mnutric_total_subq
         _make_subquery_builder(literal(None)),  # glim_diag_subq
         _make_subquery_builder(literal(None)),  # glim_fen_subq
         _make_subquery_builder(literal(None)),  # glim_etiol_subq
@@ -117,10 +123,14 @@ def test_get_patients_without_optional_filters(monkeypatch):
     result = repo.get_patients()
 
     assert result == rows
-    assert mocked_session.query.call_count == 10
+    assert mocked_session.query.call_count == 12
     main_query.select_from.assert_called_once_with(Patient)
     assert main_query.outerjoin.call_count == 4
     assert main_query.filter.call_count == 1
+    main_query.order_by.assert_called_once()
+    order_args = main_query.order_by.call_args.args
+    assert len(order_args) == 7
+    assert isinstance(order_args[0], Case)
     main_query.all.assert_called_once_with()
 
     first_join_target = main_query.outerjoin.call_args_list[0].args[0]
@@ -138,10 +148,7 @@ def test_get_patients_builds_last_assessment_subquery(monkeypatch):
     last_assessment_query.distinct.assert_called_once_with(
         NutritionalAssessment.nratendimento
     )
-    assert last_assessment_query.group_by.call_args.args == (
-        NutritionalAssessment.nratendimento,
-        NutritionalAssessment.frequencia,
-    )
+    assert last_assessment_query.order_by.call_count == 1
     last_assessment_query.subquery.assert_called_once_with("last_assessment")
 
 


### PR DESCRIPTION
# US-BE-13 | Ordenação de `pri` na listagem nutricional

**Base:** develop

## Resumo
Ajusta a ordenação da fila de pacientes nutricionais para que o `pri` seja derivado de uma ordem determinística por severidade e score do protocolo, com critérios clínicos de desempate.

## O que foi feito
- Implementada ordenação da query por `sev`, score do protocolo (UTI -> mNUTRIC com fallback NRS), `d7`, `haval`, UTI, dias e desempate determinístico.
- Criadas subqueries de score NRS/mNUTRIC para desempate por score.
- Ajustados testes unitários do repositório.
- Atualizada documentação da regra de ordenação.

## Critérios de aceite atendidos (parcial)
- `pri` ordenado por `cr > al > md > bx` com desempate por score e critérios adicionais.

## Observações sobre `haval`
- No backend atual, `haval` na listagem ativa é calculado a partir de `nutricional_avaliacao.created_at` (não da triagem).
- O endpoint legado apenas repassa `triagem.haval` (coluna persistida), sem recálculo em Python; se houver divergência, a origem tende a estar em SQL (view/trigger/job) fora do serviço.

## Testes
- `make test-file FILE=tests/unit/test_nutritional_patients_repository.py`

## Risco
Baixo. Mudança isolada na ordenação da listagem.

## Checklist
- [ ] Testes unitários
- [ ] Testes de integração
- [ ] Validação em dados de demo
