### PR TITLE
Us be 23 campo1 deve incluir nrs 2002 em pacientes uti pequena   2pts

### DIFF
--- a/services/nutritional/nutritional_active_patients_service.py
+++ b/services/nutritional/nutritional_active_patients_service.py
@@ -159,11 +159,13 @@ def _build_campo1(protocolo, row):
     Returns None if no score has been calculated yet for this admission.
     For MNUTRIC patients, NRS scores are included when available.
     """
+    if not row:
+        return None
     nrs = row.nrs_data or {}
     mn = row.mnutric_data or {}
     nrs_dict: Optional[dict] = None
-    if nrs and nrs.get("nrs_total"):
-        nrs_dict =  {
+    if nrs and nrs.get("nrs_total") is not None:
+        nrs_dict = {
             "nrs_total": nrs["nrs_total"],
             "nrs_dims": {
                 "nut": nrs.get("nrs_nut") or 0,
@@ -177,6 +179,8 @@ def _build_campo1(protocolo, row):
     if protocolo == "MNUTRIC":
         if not mn and not nrs_dict:
             return None
+        if not mn and nrs_dict:
+            return nrs_dict
 
         apache_manual = mn.get("mn_apache_manual") or False
         sofa_manual = mn.get("mn_sofa_manual") or False

--- a/services/nutritional/nutritional_active_patients_service.py
+++ b/services/nutritional/nutritional_active_patients_service.py
@@ -161,11 +161,9 @@ def _build_campo1(protocolo, row):
     """
     nrs = row.nrs_data or {}
     mn = row.mnutric_data or {}
-
-    if protocolo == "NRS2002":
-        if not nrs or nrs.get("nrs_total") is None:
-            return None
-        return {
+    nrs_dict: Optional[dict] = None
+    if nrs and nrs.get("nrs_total"):
+        nrs_dict =  {
             "nrs_total": nrs["nrs_total"],
             "nrs_dims": {
                 "nut": nrs.get("nrs_nut") or 0,
@@ -173,9 +171,11 @@ def _build_campo1(protocolo, row):
                 "idade": nrs.get("nrs_idade") or 0,
             },
         }
+    if protocolo == "NRS2002":
+        return nrs_dict
 
     if protocolo == "MNUTRIC":
-        if not mn:
+        if not mn and not nrs_dict:
             return None
 
         apache_manual = mn.get("mn_apache_manual") or False
@@ -183,7 +183,7 @@ def _build_campo1(protocolo, row):
         dados_incompletos = not apache_manual or not sofa_manual
 
         if dados_incompletos:
-            return {
+            dados_incompletos_dict: dict = {
                 "dados_incompletos": True,
                 "mn_dims": {
                     "idade": mn.get("mn_idade") or 0,
@@ -193,7 +193,9 @@ def _build_campo1(protocolo, row):
                     "dias": mn.get("mn_dias") or 0,
                 },
             }
-
+            if nrs_dict:
+                return dados_incompletos_dict | nrs_dict
+            return dados_incompletos_dict
         result = {
             "mnutric_total": mn["mn_total"],
             "mn_dims": {
@@ -204,13 +206,8 @@ def _build_campo1(protocolo, row):
                 "dias": mn.get("mn_dias") or 0,
             },
         }
-        if nrs and nrs.get("nrs_total") is not None:
-            result["nrs_total"] = nrs["nrs_total"]
-            result["nrs_dims"] = {
-                "nut": nrs.get("nrs_nut") or 0,
-                "doenca": nrs.get("nrs_doenca") or 0,
-                "idade": nrs.get("nrs_idade") or 0,
-            }
+        if nrs_dict:
+            return result | nrs_dict
         return result
 
     return None

--- a/services/nutritional/nutritional_job_service.py
+++ b/services/nutritional/nutritional_job_service.py
@@ -79,7 +79,6 @@ def _recalculate_schema(schema: str) -> tuple:
                         schema,
                     )
                     errors += 1
-                    continue
                 logger.info(
                     "mNUTRIC recalculado nratendimento=%s schema=%s",
                     patient.nratendimento,

--- a/tests/unit/test_nutritional_job_service.py
+++ b/tests/unit/test_nutritional_job_service.py
@@ -97,6 +97,9 @@ class TestRecalculateNutritionalScores:
         assert mock_error.call_count == 1
 
     def test_logs_error_for_icu_patient_when_recalculation_returns_none(self):
+        """mNUTRIC returning None is logged as an error, but NRS-2002 must still
+        run and be committed for the ICU patient (the two scores are independent).
+        """
         patients = [_make_patient(10, True)]
 
         with patch(
@@ -118,7 +121,7 @@ class TestRecalculateNutritionalScores:
         ) as mock_commit, patch.object(job_service.logger, "error") as mock_error:
             job_service.recalculate_nutritional_scores(flask_app)
 
-        mock_commit.assert_not_called()
+        mock_commit.assert_called_once()
         assert any("retorno None" in str(call) for call in mock_error.call_args_list)
 
     def test_logs_summary_after_run(self):

--- a/tests/unit/test_nutritional_patients_service.py
+++ b/tests/unit/test_nutritional_patients_service.py
@@ -345,3 +345,73 @@ def test_build_campo1_incomplete_mnutric_includes_nrs_when_available():
         },
     }
 
+
+def test_build_campo1_nrs_total_zero_is_valid():
+    # nrs_total=0 is a legitimate score and must not be dropped
+    row = SimpleNamespace(
+        nrs_data={"nrs_total": 0, "nrs_nut": 0, "nrs_doenca": 0, "nrs_idade": 0},
+        mnutric_data=None,
+    )
+
+    assert service._build_campo1("NRS2002", row) == {
+        "nrs_total": 0,
+        "nrs_dims": {"nut": 0, "doenca": 0, "idade": 0},
+    }
+
+
+def test_build_campo1_mnutric_without_nrs():
+    # MNUTRIC patient with no NRS screening done yet
+    row = SimpleNamespace(
+        nrs_data=None,
+        mnutric_data={
+            "mn_total": 5,
+            "mn_idade": 1,
+            "mn_apache": 2,
+            "mn_sofa": 1,
+            "mn_comor": 1,
+            "mn_dias": 0,
+            "mn_apache_manual": True,
+            "mn_sofa_manual": True,
+        },
+    )
+
+    assert service._build_campo1("MNUTRIC", row) == {
+        "mnutric_total": 5,
+        "mn_dims": {"idade": 1, "apache": 2, "sofa": 1, "comor": 1, "dias": 0},
+    }
+
+
+def test_build_campo1_incomplete_mnutric_without_nrs():
+    # Incomplete MNUTRIC (missing manual scores) with no NRS available
+    row = SimpleNamespace(
+        nrs_data=None,
+        mnutric_data={
+            "mn_total": 3,
+            "mn_idade": 1,
+            "mn_apache": 1,
+            "mn_sofa": 1,
+            "mn_comor": 0,
+            "mn_dias": 1,
+            "mn_apache_manual": False,
+            "mn_sofa_manual": False,
+        },
+    )
+
+    assert service._build_campo1("MNUTRIC", row) == {
+        "dados_incompletos": True,
+        "mn_dims": {"idade": 1, "apache": None, "sofa": None, "comor": 0, "dias": 1},
+    }
+
+
+def test_build_campo1_mnutric_only_nrs_no_mn_data():
+    # ICU patient with NRS done but MNUTRIC not yet started
+    row = SimpleNamespace(
+        nrs_data={"nrs_total": 3, "nrs_nut": 1, "nrs_doenca": 1, "nrs_idade": 1},
+        mnutric_data=None,
+    )
+
+    assert service._build_campo1("MNUTRIC", row) == {
+        "nrs_total": 3,
+        "nrs_dims": {"nut": 1, "doenca": 1, "idade": 1},
+    }
+

--- a/tests/unit/test_nutritional_patients_service.py
+++ b/tests/unit/test_nutritional_patients_service.py
@@ -243,3 +243,105 @@ def test_get_patients_maps_nrs_row_defaults_and_unknown_frequency(monkeypatch):
         },
     }
 
+
+def test_build_campo1_returns_nrs_for_nrs_protocol():
+    row = SimpleNamespace(
+        nrs_data={
+            "nrs_total": 3,
+            "nrs_nut": 1,
+            "nrs_doenca": 1,
+            "nrs_idade": 1,
+        },
+        mnutric_data=None,
+    )
+
+    assert service._build_campo1("NRS2002", row) == {
+        "nrs_total": 3,
+        "nrs_dims": {
+            "nut": 1,
+            "doenca": 1,
+            "idade": 1,
+        },
+    }
+
+
+def test_build_campo1_returns_none_when_no_nrs_for_nrs_protocol():
+    row = SimpleNamespace(nrs_data=None, mnutric_data=None)
+    assert service._build_campo1("NRS2002", row) is None
+
+
+def test_build_campo1_includes_nrs_for_mnutric_protocol():
+    row = SimpleNamespace(
+        nrs_data={
+            "nrs_total": 2,
+            "nrs_nut": 1,
+            "nrs_doenca": 0,
+            "nrs_idade": 1,
+        },
+        mnutric_data={
+            "mn_total": 6,
+            "mn_idade": 2,
+            "mn_apache": 1,
+            "mn_sofa": 1,
+            "mn_comor": 1,
+            "mn_dias": 1,
+            "mn_apache_manual": True,
+            "mn_sofa_manual": True,
+        },
+    )
+
+    assert service._build_campo1("MNUTRIC", row) == {
+        "mnutric_total": 6,
+        "mn_dims": {
+            "idade": 2,
+            "apache": 1,
+            "sofa": 1,
+            "comor": 1,
+            "dias": 1,
+        },
+        "nrs_total": 2,
+        "nrs_dims": {
+            "nut": 1,
+            "doenca": 0,
+            "idade": 1,
+        },
+    }
+
+
+def test_build_campo1_incomplete_mnutric_includes_nrs_when_available():
+    row = SimpleNamespace(
+        nrs_data={
+            "nrs_total": 4,
+            "nrs_nut": 2,
+            "nrs_doenca": 1,
+            "nrs_idade": 1,
+        },
+        mnutric_data={
+            "mn_total": 4,
+            "mn_idade": 1,
+            "mn_apache": 2,
+            "mn_sofa": 1,
+            "mn_comor": 0,
+            "mn_dias": 2,
+            "mn_apache_manual": False,
+            "mn_sofa_manual": True,
+        },
+    )
+
+    assert service._build_campo1("MNUTRIC", row) == {
+        "dados_incompletos": True,
+        "mn_dims": {
+            "idade": 1,
+            "apache": None,
+            "sofa": None,
+            "comor": 0,
+            "dias": 2,
+        },
+        "nrs_total": 4,
+        "nrs_dims": {
+            "nut": 2,
+            "doenca": 1,
+            "idade": 1,
+        },
+    }
+


### PR DESCRIPTION
# US-BE-23 · Campo1 inclui NRS-2002 em pacientes UTI

**Base:** develop

## Resumo

Ajusta `_build_campo1` para mesclar o score NRS-2002 no payload de pacientes UTI (protocolo MNUTRIC), mantendo pacientes de alas gerais com apenas NRS-2002. Antes da correção, o score NRS-2002 era ignorado para pacientes UTI, mesmo quando já tinha sido calculado.

## O que foi feito

- **Lógica:** `nrs_dict` é construído uma única vez e reaproveitado em todos os caminhos do MNUTRIC — completo, incompleto (`dados_incompletos`) e MNUTRIC ausente (apenas NRS disponível).
- **Job de recálculo (`nutritional_job_service._recalculate_schema`):** removido o `continue` que pulava o paciente UTI quando `recalculate_mnutric` retornava `None`. Esse desvio impedia que `recalculate_nrs` fosse chamado, deixando o NRS-2002 sem cálculo mesmo sendo válido. Agora a falha de mNUTRIC é apenas logada/contabilizada em `errors` e a execução prossegue para o cálculo do NRS-2002 — forçando o cálculo do NRS-2002 independentemente do estado do mNUTRIC.
- **Testes unitários adicionados** em `tests/unit/test_nutritional_patients_service.py`:
  - `test_build_campo1_nrs_total_zero_is_valid` — garante que `nrs_total = 0` é um score válido e não é descartado por checagem de falsiness.
  - `test_build_campo1_mnutric_without_nrs` — MNUTRIC completo sem NRS disponível retorna apenas o payload mNUTRIC.
  - `test_build_campo1_incomplete_mnutric_without_nrs` — MNUTRIC incompleto sem NRS retorna `dados_incompletos` sem chaves NRS.
  - `test_build_campo1_mnutric_only_nrs_no_mn_data` — paciente UTI com NRS calculado mas MNUTRIC ainda não iniciado retorna apenas o payload NRS.

## Critérios de aceite atendidos

- ✓ UTI retorna mNUTRIC + NRS-2002 quando ambos existem.
- ✓ UTI retorna somente NRS-2002 quando MNUTRIC ainda não foi iniciado.
- ✓ Alas gerais retornam somente NRS-2002.
- ✓ `nrs_total = 0` é preservado (não descartado como falsy).
- ✓ Sem nenhum score calculado, retorna `None` — comportamento inalterado.
- ✓ No job de recálculo, falha no mNUTRIC de paciente UTI não impede mais o cálculo do NRS-2002.

## Risco

Baixo. Mudança isolada na montagem de payload; sem alterações em queries ou modelos. Coberta por testes unitários.

## Checklist

- [x] Testes unitários
- [ ] Testes de integração
- [ ] Validação em dados de demo

## Issue vinculada

US-BE-23 · issue #101
