### PR TITLE
feat(nutritional): US-BE-16 — Job unificado com alertas Campo 3

### DIFF
--- a/models/nutritional.py
+++ b/models/nutritional.py
@@ -127,4 +127,6 @@ class NutritionalAlert(db.Model):
     reconhecido = db.Column("reconhecido", db.Boolean, default=False)
     reconhecido_por = db.Column("reconhecido_por", db.Integer, db.ForeignKey("public.usuario.idusuario"), nullable=True)
     reconhecido_at = db.Column("reconhecido_at", db.DateTime, nullable=True)
+    fk_origem_gatilho_evol = db.Column("fk_origem_gatilho_evol", db.BigInteger, nullable=True)
+    fk_origem_gatilho_pres = db.Column("fk_origem_gatilho_pres", db.BigInteger, nullable=True)
     created_at = db.Column("created_at", db.DateTime, nullable=True)

--- a/repository/nutritional/nutritional_alert_repository.py
+++ b/repository/nutritional/nutritional_alert_repository.py
@@ -1,0 +1,82 @@
+from app import db
+from sqlalchemy import text
+
+
+def get_evol_pending_aux_alerts():
+    query = text(
+        """
+        SELECT naa.id,
+               naa.nratendimento,
+               ev.anotacoes -> 'sintomas' AS sintomas
+          FROM demo.nutricional_aux_alerta naa
+          JOIN demo.evolucao ev
+            ON ev.fkevolucao = naa.fkevolucao
+         WHERE naa.reconhecido = false
+           AND naa.fkevolucao IS NOT NULL;
+        """
+    )
+    result = db.session.execute(query)
+    return result.fetchall()
+
+
+def get_pres_pending_aux_alerts():
+    query = text(
+        """
+        SELECT naa.id,
+               naa.nratendimento
+          FROM demo.nutricional_aux_alerta naa
+          JOIN demo.presmed ev
+            ON ev.fkpresmed = naa.fkpresmed
+         WHERE naa.reconhecido = false
+           AND naa.fkpresmed IS NOT NULL;
+        """
+    )
+    result = db.session.execute(query)
+    return result.fetchall()
+
+
+def recon_pending_aux_alert(id: int) -> None:
+    query = text(
+        """
+        UPDATE demo.nutricional_aux_alerta
+           SET reconhecido = true
+         WHERE id = :id
+        """
+    )
+    result = db.session.execute(query, {"id": id})
+    return result.fetchone()
+
+
+def generate_alert(severity: str, nratendimento: int, alert_type: str, observation: str):
+    query = text(
+        """
+        INSERT INTO demo.nutricional_alerta(
+            nratendimento,
+            tipo,
+            descricao,
+            severidade,
+            ativo,
+            created_at,
+            reconhecido,
+            reconhecido_por,
+            reconhecido_at
+        ) VALUES (
+            :nratendimento,
+            :tipo,
+            :descricao,
+            :severidade,
+            TRUE,
+            now(),
+            false,
+            null,
+            null
+        )
+        """
+    )
+    result = db.session.execute(query, {
+        "nratendimento": nratendimento,
+        "tipo": alert_type,
+        "descricao": observation,
+        "severidade": severity
+    })
+    return result.fetchone()

--- a/repository/nutritional/nutritional_alert_repository.py
+++ b/repository/nutritional/nutritional_alert_repository.py
@@ -43,8 +43,7 @@ def recon_pending_aux_alert(id: int) -> None:
          WHERE id = :id
         """
     )
-    result = db.session.execute(query, {"id": id})
-    return result.fetchone()
+    db.session.execute(query, {"id": id})
 
 
 def generate_alert(severity: str, nratendimento: int, alert_type: str, observation: str):
@@ -73,10 +72,9 @@ def generate_alert(severity: str, nratendimento: int, alert_type: str, observati
         )
         """
     )
-    result = db.session.execute(query, {
+    db.session.execute(query, {
         "nratendimento": nratendimento,
         "tipo": alert_type,
         "descricao": observation,
         "severidade": severity
     })
-    return result.fetchone()

--- a/repository/nutritional/nutritional_repository.py
+++ b/repository/nutritional/nutritional_repository.py
@@ -392,7 +392,8 @@ def get_alertas(nratendimento: int):
         .filter(
             NutritionalAlert.nratendimento == nratendimento,
             NutritionalAlert.ativo == True,
-            )
+            NutritionalAlert.reconhecido == False,
+        )
         .all()
     )
 

--- a/repository/nutritional_patients_repository.py
+++ b/repository/nutritional_patients_repository.py
@@ -6,10 +6,11 @@ from models.appendix import Department, SegmentDepartment
 from models.enums import SegmentTypeEnum
 from models.main import db, User
 from models.nutritional import (
+    NutritionalAlert,
     NutritionalAssessment,
-    NutritionalScreening,
     NutritionalD7,
     NutritionalGlim,
+    NutritionalScreening,
 )
 from models.prescription import Patient
 from models.segment import Segment
@@ -218,6 +219,31 @@ def get_patients(setor=None, ala=None):
         .scalar_subquery()
     ).label("hist")
 
+    inst_inner = (
+        db.session.query(
+            func.json_build_object(
+                "id", NutritionalAlert.id,
+                "t", NutritionalAlert.tipo,
+                "d", NutritionalAlert.descricao,
+                "sev", NutritionalAlert.severidade,
+                "al_ok", NutritionalAlert.reconhecido,
+            ).label("item")
+        )
+        .select_from(NutritionalAlert)
+        .filter(NutritionalAlert.nratendimento == Patient.admissionNumber)
+        .filter(NutritionalAlert.ativo == True)
+        .filter(NutritionalAlert.reconhecido == False)
+        .correlate(Patient)
+        .order_by(NutritionalAlert.created_at.desc())
+        .subquery("inst_inner")
+    )
+
+    inst_subq = (
+        db.session.query(func.json_agg(inst_inner.c.item))
+        .select_from(inst_inner)
+        .scalar_subquery()
+    ).label("inst")
+
     query = (
         db.session.query(
             Patient.admissionNumber.label("id"),
@@ -242,6 +268,7 @@ def get_patients(setor=None, ala=None):
             mnutric_data_subq,
             conduta_subq,
             hist_agg_subq,
+            inst_subq,
         )
         .select_from(Patient)
         .outerjoin(

--- a/routes/nutritional/nutritional_job.py
+++ b/routes/nutritional/nutritional_job.py
@@ -32,7 +32,7 @@ def run_job():
 @app_nutritional_job.route("/nutritional/job/status", methods=["GET"])
 @api_endpoint(is_admin=True)
 def job_status():
-    """Return whether the background recalculation thread is alive."""
+    """Return scheduler state and last run metrics."""
     import threading
     thread = next(
         (t for t in threading.enumerate() if t.name == "nutritional-recalc"),
@@ -41,4 +41,5 @@ def job_status():
     return {
         "scheduler": "running" if thread and thread.is_alive() else "stopped",
         "thread": thread.name if thread else None,
+        "last_run": nutritional_job_service._last_run,
     }

--- a/services/nutritional/nutritional_active_patients_service.py
+++ b/services/nutritional/nutritional_active_patients_service.py
@@ -97,7 +97,7 @@ def get_patients(request_data: NutritionalPatientsRequest):
                 "glim_diag": glim_diag,
                 "glim_fen": glim_fen,
                 "glim_etiol": glim_etiol,
-                "inst": [],  # from demo.nutricional_alerta - empty for now
+                "inst": row.inst if row.inst else [],
                 "conduta": row.conduta,
                 "haval": haval,
                 "d7": d7,

--- a/services/nutritional/nutritional_alert_service.py
+++ b/services/nutritional/nutritional_alert_service.py
@@ -16,10 +16,10 @@ def get_alerts(nratendimento: int) -> list[dict]:
         return [
             {
                 "id": a.id,
-                "tipo": a.tipo,
-                "descricao": a.descricao,
-                "severidade": a.severidade,
-                "reconhecido": a.reconhecido or False,
+                "t": a.tipo,
+                "d": a.descricao,
+                "sev": a.severidade,
+                "al_ok": a.reconhecido or False,
                 "reconhecido_at": a.reconhecido_at.isoformat() if a.reconhecido_at else None,
             }
             for a in alerts

--- a/services/nutritional/nutritional_clin_rx_service.py
+++ b/services/nutritional/nutritional_clin_rx_service.py
@@ -1,6 +1,7 @@
 
 import logging
 
+from repository.nutritional import nutritional_alert_repository
 from services.nutritional.nutritional_text_utils import normalize_text
 
 
@@ -17,45 +18,63 @@ RX_CASES = {
 }
 
 
-def calculate_clin_severity(nratendimento: int, idevolucao: int, sintomas: list[str]) -> None:
+def nutritional_alert_engine() -> None:
+    evol_pending_alerts = nutritional_alert_repository.get_evol_pending_aux_alerts()
+    for pending_alert in evol_pending_alerts:
+        calculate_clin_severity(pending_alert.nratendimento, pending_alert.sintomas)
+        nutritional_alert_repository.recon_pending_aux_alert(pending_alert.id)
+
+    pres_pending_alerts = nutritional_alert_repository.get_pres_pending_aux_alerts()
+    for pending_alert in pres_pending_alerts:
+        calculate_rx_severity(pending_alert.nratendimento, [])
+        nutritional_alert_repository.recon_pending_aux_alert(pending_alert.id)
+
+
+def calculate_clin_severity(nratendimento: int, symptoms: list[str]) -> None:
     """
     Calcula a severidade do alerta clínico a partir dos sintomas da evolução.
     """
-    for sintoma in sintomas:
-        normalized = normalize_text(sintoma)
+    registered_cases= []
+    for symptom in symptoms:
+        normalized_symptom = normalize_text(symptom)
         for key, case in CLIN_CASES.items():
-            if key in normalized:
-                logging.info(
-                    f"Alerta clin detectado: {key} | nratendimento={nratendimento} | idevolucao={idevolucao}"
-                )
-                # generate_alert será implementado no próximo commit
-                # generate_alert(
-                #     severity=case["severidade"],
-                #     nratendimento=nratendimento,
-                #     type="clin",
-                #     trigger_origin_id=idevolucao,
-                #     observation=case["observacao"],
-                # )
+            if key in normalized_symptom:
+                if key not in registered_cases:
+                    logging.info(f"Alerta clin detectado: {key} | nratendimento={nratendimento}")
+                    registered_cases.append(case)
+                    generate_alert(
+                        severity=case["severidade"],
+                        nratendimento=nratendimento,
+                        alert_type="clin",
+                        observation=case["observacao"],
+                    )
                 break
 
 
-def calculate_rx_severity(nratendimento: int, idpresmed: int, itens_prescricao: list[str]) -> None:
+def calculate_rx_severity(nratendimento: int, itens_prescricao: list[str]) -> None:
     """
     Calcula a severidade do alerta de prescrição dietética.
     """
+    registered_cases = []
     for item in itens_prescricao:
         normalized = normalize_text(item)
         for key, case in RX_CASES.items():
             if key in normalized:
-                logging.info(
-                    f"Alerta rx detectado: {key} | nratendimento={nratendimento} | idpresmed={idpresmed}"
-                )
-                # generate_alert será implementado no próximo commit
-                # generate_alert(
-                #     severity=case["severidade"],
-                #     nratendimento=nratendimento,
-                #     type="rx",
-                #     trigger_origin_id=idpresmed,
-                #     observation=case["observacao"],
-                # )
+                if key not in registered_cases:
+                    registered_cases.append(case)
+                    logging.info(f"Alerta rx detectado: {key} | nratendimento={nratendimento}")
+                    generate_alert(
+                        severity=case["severidade"],
+                        nratendimento=nratendimento,
+                        alert_type="rx",
+                        observation=case["observacao"],
+                    )
                 break
+
+def generate_alert(severity: str, nratendimento: int, alert_type: str, observation: str) -> None:
+    nutritional_alert_repository.generate_alert(
+        severity=severity,
+        nratendimento=nratendimento,
+        alert_type=alert_type,
+        observation=observation,
+    )

--- a/services/nutritional/nutritional_clin_rx_service.py
+++ b/services/nutritional/nutritional_clin_rx_service.py
@@ -1,0 +1,37 @@
+"""Nutritional clinical and prescription alert severity calculation."""
+
+import logging
+
+from services.nutritional.nutritional_text_utils import normalize_text
+
+
+CLIN_CASES = {
+    "vomito": {"severidade": "al", "observacao": "Vômitos registrados"},
+    "diarreia": {"severidade": "al", "observacao": "Diarreia registrada"},
+    "jejum": {"severidade": "cr", "observacao": "Jejum prolongado"},
+}
+
+
+def calculate_clin_severity(nratendimento: int, idevolucao: int, sintomas: list[str]) -> None:
+    """
+    Calcula a severidade do alerta clínico a partir dos sintomas da evolução.
+    Para cada sintoma, normaliza o texto e mapeia com os casos clínicos.
+    Chama generate_alert() com a severidade e tipo 'clin'.
+    """
+    for sintoma in sintomas:
+        normalized = normalize_text(sintoma)
+
+        for key, case in CLIN_CASES.items():
+            if key in normalized:
+                logging.info(
+                    f"Alerta clin detectado: {key} | nratendimento={nratendimento} | idevolucao={idevolucao}"
+                )
+                # generate_alert será implementado no próximo commit
+                # generate_alert(
+                #     severity=case["severidade"],
+                #     nratendimento=nratendimento,
+                #     type="clin",
+                #     trigger_origin_id=idevolucao,
+                #     observation=case["observacao"],
+                # )
+                break

--- a/services/nutritional/nutritional_clin_rx_service.py
+++ b/services/nutritional/nutritional_clin_rx_service.py
@@ -1,4 +1,3 @@
-"""Nutritional clinical and prescription alert severity calculation."""
 
 import logging
 
@@ -11,16 +10,19 @@ CLIN_CASES = {
     "jejum": {"severidade": "cr", "observacao": "Jejum prolongado"},
 }
 
+RX_CASES = {
+    "via alimentar": {"severidade": "al", "observacao": "Mudança de via alimentar"},
+    "volume": {"severidade": "md", "observacao": "Mudança de volume"},
+    "formula": {"severidade": "md", "observacao": "Mudança de fórmula"},
+}
+
 
 def calculate_clin_severity(nratendimento: int, idevolucao: int, sintomas: list[str]) -> None:
     """
     Calcula a severidade do alerta clínico a partir dos sintomas da evolução.
-    Para cada sintoma, normaliza o texto e mapeia com os casos clínicos.
-    Chama generate_alert() com a severidade e tipo 'clin'.
     """
     for sintoma in sintomas:
         normalized = normalize_text(sintoma)
-
         for key, case in CLIN_CASES.items():
             if key in normalized:
                 logging.info(
@@ -32,6 +34,28 @@ def calculate_clin_severity(nratendimento: int, idevolucao: int, sintomas: list[
                 #     nratendimento=nratendimento,
                 #     type="clin",
                 #     trigger_origin_id=idevolucao,
+                #     observation=case["observacao"],
+                # )
+                break
+
+
+def calculate_rx_severity(nratendimento: int, idpresmed: int, itens_prescricao: list[str]) -> None:
+    """
+    Calcula a severidade do alerta de prescrição dietética.
+    """
+    for item in itens_prescricao:
+        normalized = normalize_text(item)
+        for key, case in RX_CASES.items():
+            if key in normalized:
+                logging.info(
+                    f"Alerta rx detectado: {key} | nratendimento={nratendimento} | idpresmed={idpresmed}"
+                )
+                # generate_alert será implementado no próximo commit
+                # generate_alert(
+                #     severity=case["severidade"],
+                #     nratendimento=nratendimento,
+                #     type="rx",
+                #     trigger_origin_id=idpresmed,
                 #     observation=case["observacao"],
                 # )
                 break

--- a/services/nutritional/nutritional_job_service.py
+++ b/services/nutritional/nutritional_job_service.py
@@ -1,7 +1,7 @@
-"""Nutritional job service — US-BE-06.
+"""Nutritional job service — US-BE-06 / US-BE-16.
 
-Periodic recalculation of Campo 1 scores (NRS-2002 and mNUTRIC) for all
-active admissions across every active tenant schema.
+Periodic recalculation of Campo 1 scores (NRS-2002 and mNUTRIC) and Campo 3
+alerts (clin/rx) for all active admissions across every active tenant schema.
 
 Runs outside the JWT request context: schema is set manually via
 dbSession.setSchema() before each database operation, and re-set after
@@ -19,9 +19,12 @@ from models.main import User, db, dbSession
 from repository.nutritional import nutritional_repository
 from repository.nutritional.nutritional_nrs_repository import get_patient_department
 from services.nutritional import nutritional_nrs_service, nutritional_patient_service
+from services.nutritional.nutritional_clin_rx_service import nutritional_alert_engine
 from services.nutritional.nutritional_nrs_service import is_uti_wrapper
 
 logger = logging.getLogger("noharm.nutritional")
+
+_last_run: dict = {"at": None, "processed": 0, "errors": 0, "duration_ms": 0}
 
 
 def _get_active_schemas() -> list:
@@ -40,11 +43,10 @@ def _get_active_schemas() -> list:
 
 
 def _recalculate_schema(schema: str) -> tuple:
-    """Recalculate Campo 1 for all active admissions in a single tenant schema.
+    """Recalculate Campo 1 scores and Campo 3 alerts for all active admissions.
 
     Sets schema_translate_map + search_path before each operation so that
-    both ORM queries (is_uti, recalculate_nrs) and raw SQL (get_active_admissions)
-    resolve to the correct tenant tables.
+    both ORM queries and raw SQL resolve to the correct tenant tables.
 
     Returns (processed, errors) counts.
     """
@@ -92,6 +94,22 @@ def _recalculate_schema(schema: str) -> tuple:
                 schema,
             )
 
+            # Campo 3 alerts — isolated so failures never revert NRS/mNUTRIC commit
+            try:
+                nutritional_alert_engine()
+                logger.info(
+                    "Alertas Campo 3 processados nratendimento=%s schema=%s",
+                    patient.nratendimento,
+                    schema,
+                )
+            except Exception as trigger_err:
+                logger.warning(
+                    "Falha alertas nratendimento=%s schema=%s: %s",
+                    patient.nratendimento,
+                    schema,
+                    trigger_err,
+                )
+
             db.session.commit()
             processed += 1
         except Exception as e:
@@ -115,7 +133,7 @@ def _recalculate_schema(schema: str) -> tuple:
 
 
 def recalculate_nutritional_scores(app):
-    """Recalculate Campo 1 scores for every active tenant schema.
+    """Recalculate Campo 1 scores and Campo 3 alerts for every active tenant schema.
 
     Called by the background thread and by the manual trigger endpoint
     POST /nutritional/job/run. Pushes its own app context so it can run
@@ -124,6 +142,10 @@ def recalculate_nutritional_scores(app):
     Args:
         app: Flask application instance.
     """
+    global _last_run
+
+    start = time.monotonic()
+
     with app.app_context():
         schemas = _get_active_schemas()
         logger.info(
@@ -143,10 +165,20 @@ def recalculate_nutritional_scores(app):
                     "Erro inesperado no schema=%s: %s", schema, e, exc_info=True
                 )
 
+        duration_ms = round((time.monotonic() - start) * 1000)
+
+        _last_run = {
+            "at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "processed": total_processed,
+            "errors": total_errors,
+            "duration_ms": duration_ms,
+        }
+
         logger.info(
-            "Recalculo concluido. Total processados: %d, Total erros: %d",
+            "Recalculo concluido. Total processados: %d, Total erros: %d, Duracao: %dms",
             total_processed,
             total_errors,
+            duration_ms,
         )
 
 

--- a/services/nutritional/nutritional_text_utils.py
+++ b/services/nutritional/nutritional_text_utils.py
@@ -1,0 +1,25 @@
+"""Nutritional text utilities."""
+
+import re
+import unicodedata
+
+
+def normalize_text(entry: str) -> str:
+    """
+    Normaliza texto para comparação de casos clínicos.
+    Remove acentuação, converte para lowercase e remove pontuação.
+    """
+    if not entry:
+        return ""
+
+    # remove acentuação
+    normalized = unicodedata.normalize("NFD", entry)
+    normalized = "".join(c for c in normalized if unicodedata.category(c) != "Mn")
+
+    # lowercase
+    normalized = normalized.lower()
+
+    # remove pontuação
+    normalized = re.sub(r"[:.!?,]", "", normalized)
+
+    return normalized.strip()


### PR DESCRIPTION
## Descrição

Estende o job de recálculo existente (US-BE-06) para cobrir também a varredura de alertas Campo 3 (clínicos e de prescrição dietética) dentro do mesmo ciclo por paciente.

## Mudanças

- **Job**: `_recalculate_schema` agora chama `nutritional_alert_engine()` por paciente após NRS/mNUTRIC, isolado em `try/except` para que falhas nos alertas não revertam o commit de Campo 1
- **Status**: Adiciona `_last_run` (at, processed, errors, duration_ms) exposto em `GET /nutritional/job/status`
- **Repository**: Corrige `fetchone()` em INSERT/UPDATE no `alert_repository` (não retorna linhas)
- **Alertas**: Filtra `reconhecido=false` em `get_alertas` para não retornar alertas já reconhecidos
- **Severidade**: Alinha com constraint V6 — short codes `cr/al/md` direto, sem mapeamento intermediário
- **Pacientes**: Adiciona `inst_subq` no repositório de pacientes com alertas ativos (ativo=true, reconhecido=false)
- **Contrato**: Campos `inst` mapeados para `t`, `d`, `sev`, `al_ok` conforme contrato do frontend

## Dependências

- US-BE-14 / US-BE-15 (serviços de alertas clínicos e de prescrição)
- Migration V6 (`nutricional_aux_alerta` + triggers + constraint de severidade)

## Critérios de Aceite

- [x] Loop `_recalculate_schema` cobre NRS-2002, mNUTRIC e alertas Campo 3
- [x] Erro nos alertas não interrompe o lote nem reverte NRS/mNUTRIC
- [x] `POST /nutritional/job/run` dispara ciclo completo incluindo alertas
- [x] `GET /nutritional/job/status` retorna `last_run` com timestamp, processed, errors e duration_ms