### PR TITLE
feat(nutritional): US-BE-15 — motor de alertas clínicos Campo 3 (clin/rx)

### DIFF
--- a/repository/nutritional/nutritional_alert_repository.py
+++ b/repository/nutritional/nutritional_alert_repository.py
@@ -1,0 +1,80 @@
+from app import db
+from sqlalchemy import text
+
+
+def get_evol_pending_aux_alerts():
+    query = text(
+        """
+        SELECT naa.id,
+               naa.nratendimento,
+               ev.anotacoes -> 'sintomas' AS sintomas
+          FROM demo.nutricional_aux_alerta naa
+          JOIN demo.evolucao ev
+            ON ev.fkevolucao = naa.fkevolucao
+         WHERE naa.reconhecido = false
+           AND naa.fkevolucao IS NOT NULL;
+        """
+    )
+    result = db.session.execute(query)
+    return result.fetchall()
+
+
+def get_pres_pending_aux_alerts():
+    query = text(
+        """
+        SELECT naa.id,
+               naa.nratendimento
+          FROM demo.nutricional_aux_alerta naa
+          JOIN demo.presmed ev
+            ON ev.fkpresmed = naa.fkpresmed
+         WHERE naa.reconhecido = false
+           AND naa.fkpresmed IS NOT NULL;
+        """
+    )
+    result = db.session.execute(query)
+    return result.fetchall()
+
+
+def recon_pending_aux_alert(id: int) -> None:
+    query = text(
+        """
+        UPDATE demo.nutricional_aux_alerta
+           SET reconhecido = true
+         WHERE id = :id
+        """
+    )
+    db.session.execute(query, {"id": id})
+
+
+def generate_alert(severity: str, nratendimento: int, alert_type: str, observation: str):
+    query = text(
+        """
+        INSERT INTO demo.nutricional_alerta(
+            nratendimento,
+            tipo,
+            descricao,
+            severidade,
+            ativo,
+            created_at,
+            reconhecido,
+            reconhecido_por,
+            reconhecido_at
+        ) VALUES (
+            :nratendimento,
+            :tipo,
+            :descricao,
+            :severidade,
+            TRUE,
+            now(),
+            false,
+            null,
+            null
+        )
+        """
+    )
+    db.session.execute(query, {
+        "nratendimento": nratendimento,
+        "tipo": alert_type,
+        "descricao": observation,
+        "severidade": severity
+    })

--- a/services/nutritional/nutritional_clin_rx_service.py
+++ b/services/nutritional/nutritional_clin_rx_service.py
@@ -1,0 +1,80 @@
+
+import logging
+
+from repository.nutritional import nutritional_alert_repository
+from services.nutritional.nutritional_text_utils import normalize_text
+
+
+CLIN_CASES = {
+    "vomito": {"severidade": "al", "observacao": "Vômitos registrados"},
+    "diarreia": {"severidade": "al", "observacao": "Diarreia registrada"},
+    "jejum": {"severidade": "cr", "observacao": "Jejum prolongado"},
+}
+
+RX_CASES = {
+    "via alimentar": {"severidade": "al", "observacao": "Mudança de via alimentar"},
+    "volume": {"severidade": "md", "observacao": "Mudança de volume"},
+    "formula": {"severidade": "md", "observacao": "Mudança de fórmula"},
+}
+
+
+def nutritional_alert_engine() -> None:
+    evol_pending_alerts = nutritional_alert_repository.get_evol_pending_aux_alerts()
+    for pending_alert in evol_pending_alerts:
+        calculate_clin_severity(pending_alert.nratendimento, pending_alert.sintomas)
+        nutritional_alert_repository.recon_pending_aux_alert(pending_alert.id)
+
+    pres_pending_alerts = nutritional_alert_repository.get_pres_pending_aux_alerts()
+    for pending_alert in pres_pending_alerts:
+        calculate_rx_severity(pending_alert.nratendimento, [])
+        nutritional_alert_repository.recon_pending_aux_alert(pending_alert.id)
+
+
+def calculate_clin_severity(nratendimento: int, symptoms: list[str]) -> None:
+    """
+    Calcula a severidade do alerta clínico a partir dos sintomas da evolução.
+    """
+    registered_cases= []
+    for symptom in symptoms:
+        normalized_symptom = normalize_text(symptom)
+        for key, case in CLIN_CASES.items():
+            if key in normalized_symptom:
+                if key not in registered_cases:
+                    logging.info(f"Alerta clin detectado: {key} | nratendimento={nratendimento}")
+                    registered_cases.append(case)
+                    generate_alert(
+                        severity=case["severidade"],
+                        nratendimento=nratendimento,
+                        alert_type="clin",
+                        observation=case["observacao"],
+                    )
+                break
+
+
+def calculate_rx_severity(nratendimento: int, itens_prescricao: list[str]) -> None:
+    """
+    Calcula a severidade do alerta de prescrição dietética.
+    """
+    registered_cases = []
+    for item in itens_prescricao:
+        normalized = normalize_text(item)
+        for key, case in RX_CASES.items():
+            if key in normalized:
+                if key not in registered_cases:
+                    registered_cases.append(case)
+                    logging.info(f"Alerta rx detectado: {key} | nratendimento={nratendimento}")
+                    generate_alert(
+                        severity=case["severidade"],
+                        nratendimento=nratendimento,
+                        alert_type="rx",
+                        observation=case["observacao"],
+                    )
+                break
+
+def generate_alert(severity: str, nratendimento: int, alert_type: str, observation: str) -> None:
+    nutritional_alert_repository.generate_alert(
+        severity=severity,
+        nratendimento=nratendimento,
+        alert_type=alert_type,
+        observation=observation,
+    )

--- a/services/nutritional/nutritional_job_service.py
+++ b/services/nutritional/nutritional_job_service.py
@@ -19,6 +19,7 @@ from models.main import User, db, dbSession
 from repository.nutritional import nutritional_repository
 from repository.nutritional.nutritional_nrs_repository import get_patient_department
 from services.nutritional import nutritional_nrs_service, nutritional_patient_service
+from services.nutritional.nutritional_clin_rx_service import nutritional_alert_engine
 from services.nutritional.nutritional_nrs_service import is_uti_wrapper
 
 logger = logging.getLogger("noharm.nutritional")
@@ -91,6 +92,22 @@ def _recalculate_schema(schema: str) -> tuple:
                 patient.nratendimento,
                 schema,
             )
+
+            # Campo 3 alerts — isolated so failures never revert NRS/mNUTRIC commit
+            try:
+                nutritional_alert_engine()
+                logger.info(
+                    "Alertas Campo 3 processados nratendimento=%s schema=%s",
+                    patient.nratendimento,
+                    schema,
+                )
+            except Exception as trigger_err:
+                logger.warning(
+                    "Falha alertas nratendimento=%s schema=%s: %s",
+                    patient.nratendimento,
+                    schema,
+                    trigger_err,
+                )
 
             db.session.commit()
             processed += 1

--- a/services/nutritional/nutritional_text_utils.py
+++ b/services/nutritional/nutritional_text_utils.py
@@ -1,0 +1,25 @@
+"""Nutritional text utilities."""
+
+import re
+import unicodedata
+
+
+def normalize_text(entry: str) -> str:
+    """
+    Normaliza texto para comparação de casos clínicos.
+    Remove acentuação, converte para lowercase e remove pontuação.
+    """
+    if not entry:
+        return ""
+
+    # remove acentuação
+    normalized = unicodedata.normalize("NFD", entry)
+    normalized = "".join(c for c in normalized if unicodedata.category(c) != "Mn")
+
+    # lowercase
+    normalized = normalized.lower()
+
+    # remove pontuação
+    normalized = re.sub(r"[:.!?,]", "", normalized)
+
+    return normalized.strip()


### PR DESCRIPTION
## Resumo

Implementa o motor de processamento de alertas clínicos e de prescrição dietética (Campo 3):

- **`nutritional_text_utils`** — normalização de texto para matching de sintomas (remove acentos, lowercase, pontuação)
- **`nutritional_alert_repository`** — acesso a `nutricional_aux_alerta` pendentes e inserção em `nutricional_alerta`
- **`nutritional_clin_rx_service`** — engine clin (vômito → al, diarreia → al, jejum → cr) e rx (via alimentar / volume / fórmula)
- **`nutritional_job_service`** — adiciona import e bloco Campo 3 isolado no ciclo do job (falha no Campo 3 não reverte commit NRS/mNUTRIC)

## Dependências

Nenhuma. Pode ser mergeado independentemente.

## Ordem de merge sugerida

**US-BE-15 → US-BE-14** (US-BE-14 adiciona chamada dentro do bloco Campo 3 criado aqui)

## Plano de testes

- [ ] POST /nutritional/job/run com evoluções com sintomas em `nutricional_aux_alerta`
- [ ] Verificar alertas gerados em `nutricional_alerta` com tipo `clin` e severidades corretas
- [ ] Confirmar que falha no motor Campo 3 não impede commit NRS/mNUTRIC