### PR TITLE
fix(nutritional): US-BE-14 — corrige motor de alertas laboratoriais Campo 3

### DIFF
--- a/repository/nutritional/nutritional_repository.py
+++ b/repository/nutritional/nutritional_repository.py
@@ -12,6 +12,7 @@ from models.nutritional import (
     NutritionalGlim,
     NutritionalScreening,
 )
+from models.appendix import SegmentDepartment
 from models.prescription import Patient, Prescription, PrescriptionDrug
 from models.segment import Exams, SegmentExam
 from utils import status
@@ -471,7 +472,26 @@ def get_patient_segment_id(nratendimento: int):
         .order_by(Prescription.date.desc())
         .first()
     )
-    return row.idSegment if row else None
+    if row:
+        return row.idSegment
+
+    patient = (
+        db.session.query(Patient.idHospital, Patient.idDepartment)
+        .filter(Patient.admissionNumber == nratendimento)
+        .first()
+    )
+    if not patient or patient.idDepartment is None:
+        return None
+
+    seg = (
+        db.session.query(SegmentDepartment.id)
+        .filter(
+            SegmentDepartment.idHospital == patient.idHospital,
+            SegmentDepartment.idDepartment == patient.idDepartment,
+        )
+        .first()
+    )
+    return seg.id if seg else None
 
 
 def get_exam_limit(idsegmento, tpexame: str):

--- a/services/nutritional/nutritional_job_service.py
+++ b/services/nutritional/nutritional_job_service.py
@@ -20,6 +20,7 @@ from repository.nutritional import nutritional_repository
 from repository.nutritional.nutritional_nrs_repository import get_patient_department
 from services.nutritional import nutritional_nrs_service, nutritional_patient_service
 from services.nutritional.nutritional_clin_rx_service import nutritional_alert_engine
+from services.nutritional.nutritional_lab_alert_service import process_lab_pending_alerts
 from services.nutritional.nutritional_nrs_service import is_uti_wrapper
 
 logger = logging.getLogger("noharm.nutritional")
@@ -96,6 +97,7 @@ def _recalculate_schema(schema: str) -> tuple:
             # Campo 3 alerts — isolated so failures never revert NRS/mNUTRIC commit
             try:
                 nutritional_alert_engine()
+                process_lab_pending_alerts()
                 logger.info(
                     "Alertas Campo 3 processados nratendimento=%s schema=%s",
                     patient.nratendimento,

--- a/services/nutritional/nutritional_lab_alert_service.py
+++ b/services/nutritional/nutritional_lab_alert_service.py
@@ -15,9 +15,9 @@ FOSFORO_MAGNESIO = {"P", "MG"}
 def is_exame_alterado(tpexame, resultado, min_val, max_val) -> bool:
     if resultado is None:
         return False
-    if EXAMES.get(tpexame.upper(), {}).get("dir") == "high":
-        return max_val is not None and resultado > max_val
-    return min_val is not None and resultado < min_val
+    below = min_val is not None and resultado < min_val
+    above = max_val is not None and resultado > max_val
+    return below or above
 
 
 def resolver_severidade(qtd_alterados, tem_fosforo_ou_magnesio, em_ne_npt_pos_npo):


### PR DESCRIPTION
## Resumo

Corrige bugs no motor de alertas laboratoriais que impediam detecção de valores alterados:

- **`is_exame_alterado`** — verificava apenas `resultado < min` para exames com `dir="low"`, ignorando valores acima do máximo (K↑ e MG↑ não eram detectados). Corrigido para checar `below OR above` independente do campo `dir`
- **`get_patient_segment_id`** — retornava `None` quando paciente não tinha prescrição. Adicionado fallback via `segmentosetor → SegmentDepartment` usando `idHospital + idDepartment` do paciente
- **`nutritional_job_service`** — adiciona import e chamada `process_lab_pending_alerts()` dentro do bloco Campo 3

## Dependências

Requer **US-BE-15** mergeado antes (bloco Campo 3 no job_service).

## Plano de testes

- [ ] Exames K↑ e MG↑ geram alerta (antes ficavam sem detecção)
- [ ] Pacientes sem prescrição têm segmento resolvido via setor
- [ ] Alertas lab aparecem em `nutricional_alerta` com severidade correta