### PR TITLE
feat(nutritional): US-BE-16 — integração Campo 3 no painel e rastreabilidade do job

### DIFF
--- a/repository/nutritional/nutritional_repository.py
+++ b/repository/nutritional/nutritional_repository.py
@@ -397,7 +397,8 @@ def get_alertas(nratendimento: int):
         .filter(
             NutritionalAlert.nratendimento == nratendimento,
             NutritionalAlert.ativo == True,
-            )
+            NutritionalAlert.reconhecido == False,
+        )
         .all()
     )
 

--- a/repository/nutritional_patients_repository.py
+++ b/repository/nutritional_patients_repository.py
@@ -6,10 +6,11 @@ from models.appendix import Department, SegmentDepartment
 from models.enums import SegmentTypeEnum
 from models.main import db, User
 from models.nutritional import (
+    NutritionalAlert,
     NutritionalAssessment,
-    NutritionalScreening,
     NutritionalD7,
     NutritionalGlim,
+    NutritionalScreening,
 )
 from models.prescription import Patient
 from models.segment import Segment
@@ -218,6 +219,31 @@ def get_patients(setor=None, ala=None):
         .scalar_subquery()
     ).label("hist")
 
+    inst_inner = (
+        db.session.query(
+            func.json_build_object(
+                "id", NutritionalAlert.id,
+                "t", NutritionalAlert.tipo,
+                "d", NutritionalAlert.descricao,
+                "sev", NutritionalAlert.severidade,
+                "al_ok", NutritionalAlert.reconhecido,
+            ).label("item")
+        )
+        .select_from(NutritionalAlert)
+        .filter(NutritionalAlert.nratendimento == Patient.admissionNumber)
+        .filter(NutritionalAlert.ativo == True)
+        .filter(NutritionalAlert.reconhecido == False)
+        .correlate(Patient)
+        .order_by(NutritionalAlert.created_at.desc())
+        .subquery("inst_inner")
+    )
+
+    inst_subq = (
+        db.session.query(func.json_agg(inst_inner.c.item))
+        .select_from(inst_inner)
+        .scalar_subquery()
+    ).label("inst")
+
     query = (
         db.session.query(
             Patient.admissionNumber.label("id"),
@@ -242,6 +268,7 @@ def get_patients(setor=None, ala=None):
             mnutric_data_subq,
             conduta_subq,
             hist_agg_subq,
+            inst_subq,
         )
         .select_from(Patient)
         .outerjoin(

--- a/routes/nutritional/nutritional_job.py
+++ b/routes/nutritional/nutritional_job.py
@@ -41,4 +41,5 @@ def job_status():
     return {
         "scheduler": "running" if thread and thread.is_alive() else "stopped",
         "thread": thread.name if thread else None,
+        "last_run": nutritional_job_service._last_run,
     }

--- a/services/nutritional/nutritional_active_patients_service.py
+++ b/services/nutritional/nutritional_active_patients_service.py
@@ -87,7 +87,7 @@ def get_patients(request_data: NutritionalPatientsRequest):
                 "glim_diag": glim_diag,
                 "glim_fen": glim_fen,
                 "glim_etiol": glim_etiol,
-                "inst": _build_inst(row.id),
+                "inst": row.inst if row.inst else [],
                 "conduta": row.conduta,
                 "haval": haval,
                 "d7": d7,

--- a/services/nutritional/nutritional_alert_service.py
+++ b/services/nutritional/nutritional_alert_service.py
@@ -16,12 +16,10 @@ def get_alerts(nratendimento: int) -> list[dict]:
         return [
             {
                 "id": a.id,
-                "tipo": a.tipo,
+                "t": a.tipo,
+                "d": a.descricao,
                 "sev": a.severidade,
-                "descricao": a.descricao,
-                "ativo": a.ativo if a.ativo is not None else False,
-                "reconhecido": a.reconhecido or False,
-                "reconhecido_por": a.reconhecido_por,
+                "al_ok": a.reconhecido or False,
                 "reconhecido_at": a.reconhecido_at.isoformat() if a.reconhecido_at else None,
                 "created_at": a.created_at.isoformat() if a.created_at else None,
             }

--- a/services/nutritional/nutritional_job_service.py
+++ b/services/nutritional/nutritional_job_service.py
@@ -23,6 +23,8 @@ from services.nutritional.nutritional_nrs_service import is_uti_wrapper
 
 logger = logging.getLogger("noharm.nutritional")
 
+_last_run: dict = {"at": None, "processed": 0, "errors": 0, "duration_ms": 0}
+
 
 def _get_active_schemas() -> list:
     """Return all distinct schemas with at least one active user.
@@ -124,6 +126,10 @@ def recalculate_nutritional_scores(app):
     Args:
         app: Flask application instance.
     """
+    global _last_run
+
+    start = time.monotonic()
+
     with app.app_context():
         schemas = _get_active_schemas()
         logger.info(
@@ -143,10 +149,20 @@ def recalculate_nutritional_scores(app):
                     "Erro inesperado no schema=%s: %s", schema, e, exc_info=True
                 )
 
+        duration_ms = round((time.monotonic() - start) * 1000)
+
+        _last_run = {
+            "at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "processed": total_processed,
+            "errors": total_errors,
+            "duration_ms": duration_ms,
+        }
+
         logger.info(
-            "Recalculo concluido. Total processados: %d, Total erros: %d",
+            "Recalculo concluido. Total processados: %d, Total erros: %d, Duracao: %dms",
             total_processed,
             total_errors,
+            duration_ms,
         )
 
 


### PR DESCRIPTION
## Resumo

Integra os alertas Campo 3 no painel de pacientes e adiciona rastreabilidade do job:

- **`nutritional_patients_repository`** — subquery `inst` agrega alertas ativos não reconhecidos por paciente (JSON array inline, evita N+1)
- **`nutritional_active_patients_service`** — substitui chamada `_build_inst(row.id)` por `row.inst` vindo da query
- **`nutritional_alert_service`** — renomeia campos da resposta: `tipo→t`, `descricao→d`, `reconhecido→al_ok`; remove `ativo` e `reconhecido_por`
- **`nutritional_repository`** — `get_alertas` filtra por `reconhecido=False` (alinha com o que o frontend espera)
- **`nutritional_job_service`** — adiciona `_last_run` com timestamp, contadores e `duration_ms`
- **`nutritional_job` route** — expõe `last_run` no endpoint `GET /nutritional/job/status`

## Dependências

Independente de US-BE-14 e US-BE-15. Pode ser mergeado em qualquer ordem.

## Plano de testes

- [ ] GET /nutritional/patients retorna campo `inst` com alertas ativos por paciente
- [ ] GET /nutritional/job/status retorna `last_run` após execução do job
- [ ] Alertas reconhecidos não aparecem no painel
- [ ] Campos da resposta de alertas usam nomes curtos (t, d, al_ok)