### PR TITLE
fix: estado em_andamento NRS2002 sem badge Apache/SOFA

### DIFF
--- a/services/nutritional/nutritional_active_patients_service.py
+++ b/services/nutritional/nutritional_active_patients_service.py
@@ -71,7 +71,11 @@ def build_patients_payload(rows, now=None):
         glim_etiol = row.glim_etiol if row.glim_etiol else []
 
         campo1 = _build_campo1(protocolo, row)
-        dados_incompletos = bool(campo1 and campo1.get("dados_incompletos"))
+        if protocolo == "NRS2002":
+            nrs = row.nrs_data or {}
+            dados_incompletos = bool(campo1 and nrs.get("nrs_nut") is None)
+        else:
+            dados_incompletos = bool(campo1 and campo1.get("dados_incompletos"))
         finalizada = row.triagem_finalizada_at is not None
         triagem_at = _to_iso_datetime(row.triagem_finalizada_at)
 
@@ -185,10 +189,11 @@ def _build_campo1(protocolo, row):
     mn = row.mnutric_data or {}
     nrs_dict = None
     if nrs and nrs.get("nrs_total") is not None:
+        nrs_nut = nrs.get("nrs_nut")
         nrs_dict = {
             "nrs_total": nrs["nrs_total"],
             "nrs_dims": {
-                "nut": nrs.get("nrs_nut") or 0,
+                "nut": nrs_nut if nrs_nut is not None else 0,
                 "doenca": nrs.get("nrs_doenca") or 0,
                 "idade": nrs.get("nrs_idade") or 0,
             },


### PR DESCRIPTION
## Summary

- Remove `dados_incompletos` do `campo1` para pacientes NRS2002 — esse campo é sinal exclusivo do mNUTRIC (badge Apache/SOFA)
- Detecta `triagem_status=em_andamento` NRS2002 via `nrs_nut=None` diretamente em `build_patients_payload`, sem poluir `campo1`
- Pacientes Ala B sem formulário admissional (`nutricional_nrs`) continuam aparecendo como `em_andamento` corretamente

## Test plan

- [ ] Pacientes Ala B com `triagem_status=em_andamento` não exibem badge Apache/SOFA no frontend
- [ ] Pacientes UTI com mNUTRIC incompleto continuam exibindo badge Apache/SOFA
- [ ] `GET /nutritional/patients?setor=10` retorna `campo1` sem `dados_incompletos` para NRS2002
- [ ] `triagem_status` correto para todos os estados: `pendente`, `atrasada`, `em_andamento`, `finalizada`