### PR TITLE
fix: filtro ala por nome do segmento e exclusão de pacientes sem setor

### DIFF
--- a/repository/nutritional_patients_repository.py
+++ b/repository/nutritional_patients_repository.py
@@ -302,6 +302,7 @@ def get_patients(setor=None, ala=None):
             & (Department.idHospital == Patient.idHospital),
         )
         .filter(Patient.dischargeDate.is_(None))
+        .filter(Patient.idDepartment.isnot(None))
     )
 
     sev_order = case(
@@ -344,7 +345,7 @@ def get_patients(setor=None, ala=None):
             )
 
         else:
-            query = query.filter(Segment.type.is_(None))
+            query = query.filter(Segment.description.ilike(f"%{ala}%"))
 
     query = query.order_by(
         sev_order,


### PR DESCRIPTION
## Summary

- Filtro `?ala=X` agora usa `Segment.description ILIKE '%X%'` em vez de `Segment.type IS NULL`, permitindo filtrar corretamente por Ala B, Ala C e outras alas nomeadas
- Adicionado filtro `idDepartment IS NOT NULL` para excluir pacientes sem setor (fksetor=NULL) que apareciam na listagem sem leito e sem ala

## Test plan

- [ ] `GET /nutritional/patients?ala=B` retorna apenas pacientes da Ala B com `ala='Ala B'`
- [ ] `GET /nutritional/patients?ala=C` retorna apenas pacientes da Ala C com `ala='Ala C'`
- [ ] Pacientes sem setor não aparecem mais na listagem
- [ ] Filtro `?ala=UTI` e `?ala=ENFERMARIA` continuam funcionando