### PR TITLE
feat(nutritional): US-BE-XX — endpoint GET /nutritional/indicators

### DIFF
--- a/app/blueprints.py
+++ b/app/blueprints.py
@@ -139,7 +139,9 @@ def register_blueprints(app):
     # Nutritional blueprints
     from routes.nutritional.nutritional_job import app_nutritional_job
     from  routes.nutritional.healthz import app_nutritional_health
+    from routes.nutritional.nutritional_indicators import app_nutritional_indicators
 
     app.register_blueprint(app_nutritional_health)
     app.register_blueprint(app_nutritional)
     app.register_blueprint(app_nutritional_job)
+    app.register_blueprint(app_nutritional_indicators)

--- a/models/requests/nutritional_indicators_request.py
+++ b/models/requests/nutritional_indicators_request.py
@@ -1,0 +1,13 @@
+"""Request model for GET /nutritional/indicators endpoint."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class NutritionalIndicatorsRequest(BaseModel):
+    setor: Optional[int] = None
+    ala: Optional[str] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None

--- a/repository/nutritional/nutritional_indicators_repository.py
+++ b/repository/nutritional/nutritional_indicators_repository.py
@@ -1,0 +1,75 @@
+"""Repository for GET /nutritional/indicators query."""
+
+from sqlalchemy import func, or_
+
+from models.appendix import Department, SegmentDepartment
+from models.enums import SegmentTypeEnum
+from models.main import db
+from models.nutritional import NutritionalScreening
+from models.prescription import Patient
+from models.segment import Segment
+
+
+def get_indicators_data(setor=None, ala=None, start_date=None, end_date=None):
+    """Return admitted patients in the period with their first triagem_at."""
+
+    # subquery: earliest completed triage per admission
+    first_triagem = (
+        db.session.query(
+            NutritionalScreening.nratendimento,
+            func.min(NutritionalScreening.triagem_at).label("triagem_at"),
+        )
+        .filter(NutritionalScreening.triagem_at.isnot(None))
+        .group_by(NutritionalScreening.nratendimento)
+        .subquery("first_triagem")
+    )
+
+    query = (
+        db.session.query(
+            Patient.admissionNumber.label("nratendimento"),
+            Patient.admissionDate.label("dtinternacao"),
+            first_triagem.c.triagem_at,
+        )
+        .select_from(Patient)
+        .outerjoin(
+            SegmentDepartment,
+            (SegmentDepartment.idDepartment == Patient.idDepartment)
+            & (SegmentDepartment.idHospital == Patient.idHospital),
+        )
+        .outerjoin(Segment, Segment.id == SegmentDepartment.id)
+        .outerjoin(
+            Department,
+            (Department.id == Patient.idDepartment)
+            & (Department.idHospital == Patient.idHospital),
+        )
+        .outerjoin(
+            first_triagem,
+            first_triagem.c.nratendimento == Patient.admissionNumber,
+        )
+        .filter(Patient.idDepartment.isnot(None))
+    )
+
+    if start_date is not None:
+        query = query.filter(Patient.admissionDate >= start_date)
+
+    if end_date is not None:
+        query = query.filter(Patient.admissionDate < end_date)
+
+    if setor is not None:
+        query = query.filter(Patient.idDepartment == setor)
+
+    if ala is not None:
+        ala_upper = ala.upper()
+        if ala_upper == "UTI":
+            query = query.filter(Segment.type == SegmentTypeEnum.ICU.value)
+        elif ala_upper == "ENFERMARIA":
+            query = query.filter(
+                or_(
+                    Segment.type != SegmentTypeEnum.ICU.value,
+                    Segment.type.is_(None),
+                )
+            )
+        else:
+            query = query.filter(Segment.description.ilike(f"%{ala}%"))
+
+    return query.all()

--- a/routes/nutritional/nutritional_indicators.py
+++ b/routes/nutritional/nutritional_indicators.py
@@ -1,0 +1,17 @@
+"""Route for GET /nutritional/indicators."""
+
+from flask import Blueprint, request
+
+from decorators.api_endpoint_decorator import api_endpoint
+from models.requests.nutritional_indicators_request import NutritionalIndicatorsRequest
+from services.nutritional import nutritional_indicators_service
+
+app_nutritional_indicators = Blueprint("app_nutritional_indicators", __name__)
+
+
+@app_nutritional_indicators.route("/nutritional/indicators", methods=["GET"])
+@api_endpoint()
+def get_indicators():
+    return nutritional_indicators_service.get_indicators(
+        request_data=NutritionalIndicatorsRequest(**request.args.to_dict(flat=True))
+    )

--- a/services/nutritional/nutritional_indicators_service.py
+++ b/services/nutritional/nutritional_indicators_service.py
@@ -1,0 +1,53 @@
+"""Service for GET /nutritional/indicators endpoint."""
+
+from decorators.has_permission_decorator import Permission, has_permission
+from models.requests.nutritional_indicators_request import NutritionalIndicatorsRequest
+from repository.nutritional import nutritional_indicators_repository
+
+_24H = 86400  # seconds
+
+
+@has_permission(Permission.READ_PRESCRIPTION)
+def get_indicators(
+    request_data: NutritionalIndicatorsRequest,
+    user_permissions: list[Permission],
+):
+    rows = nutritional_indicators_repository.get_indicators_data(
+        setor=request_data.setor,
+        ala=request_data.ala,
+        start_date=request_data.start_date,
+        end_date=request_data.end_date,
+    )
+
+    verde = vermelho = cinza = 0
+
+    for row in rows:
+        if row.triagem_at is None or row.dtinternacao is None:
+            cinza += 1
+            continue
+
+        triagem = row.triagem_at
+        internacao = row.dtinternacao
+
+        # normalize to naive for delta
+        if hasattr(triagem, "tzinfo") and triagem.tzinfo is not None:
+            triagem = triagem.replace(tzinfo=None)
+        if hasattr(internacao, "tzinfo") and internacao.tzinfo is not None:
+            internacao = internacao.replace(tzinfo=None)
+
+        delta = (triagem - internacao).total_seconds()
+        if delta <= _24H:
+            verde += 1
+        else:
+            vermelho += 1
+
+    total = verde + vermelho + cinza
+    percentual = round(verde / total * 100, 1) if total > 0 else 0.0
+
+    return {
+        "percentual": percentual,
+        "total": total,
+        "verde": verde,
+        "vermelho": vermelho,
+        "cinza": cinza,
+    }


### PR DESCRIPTION
## Summary

- Novo endpoint `GET /nutritional/indicators` para o indicador de triagem nutricional em 24h
- Calcula % de pacientes com triagem concluída em até 24h da internação
- Filtros opcionais: `setor`, `ala`, `start_date`, `end_date`

## Response

```json
{
  "status": "success",
  "data": {
    "percentual": 66.7,
    "total": 18,
    "verde": 12,
    "vermelho": 4,
    "cinza": 2
  }
}
```

- `verde`: triagem_at ≤ 24h da internação
- `vermelho`: triagem_at > 24h da internação
- `cinza`: sem triagem concluída
- Inclui pacientes com alta no período (indicador histórico)

## Test plan

- [ ] `GET /nutritional/indicators` retorna 200 com estrutura correta
- [ ] `GET /nutritional/indicators?ala=UTI` filtra apenas UTI
- [ ] `GET /nutritional/indicators?setor=10` filtra por setor
- [ ] `GET /nutritional/indicators?start_date=2026-01-01&end_date=2026-12-31` filtra por período
- [ ] Sem token retorna 401