### PR TITLE
fix: triagem atrasada respeita tempo mesmo com dados_incompletos

### DIFF
--- a/services/nutritional/nutritional_active_patients_service.py
+++ b/services/nutritional/nutritional_active_patients_service.py
@@ -20,17 +20,19 @@ def _to_iso_datetime(value):
 def _calc_triagem_status(data_internacao, finalizada, dados_incompletos, now):
     if finalizada:
         return "finalizada"
+    if data_internacao is None:
+        return "em_andamento" if dados_incompletos else "pendente"
+
+    dt = data_internacao
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+
+    overdue = (now - dt).total_seconds() > 86400
+
+    if overdue:
+        return "atrasada"
     if dados_incompletos:
         return "em_andamento"
-    if data_internacao is None:
-        return "pendente"
-
-    if data_internacao.tzinfo is None:
-        data_internacao = data_internacao.replace(tzinfo=timezone.utc)
-
-    if (now - data_internacao).total_seconds() > 86400:
-        return "atrasada"
-
     return "pendente"
 
 


### PR DESCRIPTION
## Summary

- Pacientes NRS-2002 com formulário incompleto (`nrs_nut = NULL`) e internação > 24h ficavam presos em `em_andamento` para sempre
- O job NRS cria a linha em `nutricional_triagem` com `nrs_total = B+C`, tornando `dados_incompletos=True` e fazendo o check de 24h ser ignorado
- Estado `atrasada` nunca aparecia na listagem de pacientes

**Fix:** mover o check `overdue > 24h` para antes do check `dados_incompletos` em `_calc_triagem_status`. Tempo domina sobre completude.

**Nova máquina de estados:**
| Estado | Condição |
|---|---|
| `finalizada` | `triagem_at` carimbado |
| `atrasada` | internação > 24h (independente de dados_incompletos) |
| `em_andamento` | form incompleto, internação < 24h |
| `pendente` | sem row, internação < 24h |

## Test plan

- [ ] Verificar endpoint `/nutritional/patients` com pacientes ALA B — pacientes com internação > 24h e `nrs_nut=NULL` devem retornar `triagem_status: "atrasada"`
- [ ] Paciente com internação < 24h e formulário incompleto deve retornar `"em_andamento"`
- [ ] Paciente com `triagem_at` setado deve retornar `"finalizada"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)