### PR TITLE
feat: endpoint PUT /nutritional/patients/{id}/nrs-a — persistir Componente A NRS-2002

### DIFF
--- a/docker-compose.nitra.yml
+++ b/docker-compose.nitra.yml
@@ -66,6 +66,11 @@ services:
       psql -h db -U postgres -d noharm -f /sql/migrations/flyway/V4__seed_data.sql &&
       psql -h db -U postgres -d noharm -f /sql/migrations/flyway/V5__nitra_test_seed.sql &&
       psql -h db -U postgres -d noharm -f /sql/migrations/flyway/V6__create_alert_utils.sql &&
+      psql -h db -U postgres -d noharm -f /sql/migrations/flyway/V7__seed_campo3_alerts.sql &&
+      psql -h db -U postgres -d noharm -f /sql/migrations/flyway/V8__fix_trigger_presmed_aux_alerta.sql &&
+      psql -h db -U postgres -d noharm -f /sql/migrations/flyway/V9__add_triagem_at.sql &&
+      psql -h db -U postgres -d noharm -f /sql/migrations/flyway/V10__seed_nrs_uti.sql &&
+      psql -h db -U postgres -d noharm -f /sql/migrations/flyway/V11__seed_ala_b_triagem_states.sql &&
       psql -h db -U postgres -d noharm -f /sql/migrations/flyway/R__users_permissions.sql
       "
 

--- a/repository/nutritional/nutritional_nrs_repository.py
+++ b/repository/nutritional/nutritional_nrs_repository.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from functools import lru_cache
 from typing import Optional
 
@@ -11,6 +12,28 @@ from models.prescription import Prescription
 from models.nutritional import NutritionalNrs, NutritionalScreening
 from models.segment import Segment
 from services.nutritional.nutritional_dtos import CidMappings, NrsScoreDTO
+
+
+def upsert_nrs_component_a(nratendimento: int, nut: int) -> NutritionalNrs:
+    """Persist NRS Component A (nutritional impairment score 0-3) for an admission."""
+    row = _get_nrs_assessment(db.session, nratendimento)
+    if row is None:
+        now = datetime.now(timezone.utc)
+        row = NutritionalNrs(
+            nratendimento=nratendimento,
+            score_gravidade=0,
+            idade_maior_70=False,
+            created_at=now,
+            updated_at=now,
+        )
+        db.session.add(row)
+    row.score_comprometimento = nut
+    row.triagem_imc_baixo = False
+    row.triagem_perda_peso = False
+    row.triagem_ingestao_reduzida = False
+    row.triagem_doenca_grave = nut > 0
+    db.session.flush()
+    return row
 
 
 def get_nrs_assessment(nratendimento: int) -> Optional[NutritionalNrs]:

--- a/routes/nutritional/nutritional_patients.py
+++ b/routes/nutritional/nutritional_patients.py
@@ -139,3 +139,12 @@ def get_d7(nratendimento):
 @api_endpoint()
 def close_d7(nratendimento, id):
     return nutritional_patient_service.close_d7(nratendimento=nratendimento, id=id)
+
+
+@app_nutritional.route(
+    "/nutritional/patients/<int:nratendimento>/nrs-a", methods=["PUT"]
+)
+@api_endpoint()
+def save_nrs_component_a(nratendimento: int):
+    nut = (request.get_json(silent=True) or {}).get("nut")
+    return nutritional_patient_service.save_nrs_component_a(nratendimento, nut)

--- a/services/nutritional/nutritional_patient_service.py
+++ b/services/nutritional/nutritional_patient_service.py
@@ -10,8 +10,12 @@ from repository import nutritional_patients_repository
 from models.nutritional import NutritionalAssessment, NutritionalD7, NutritionalGlim
 from models.requests.nutritional_glim_request import diagnostico_to_api
 from repository.nutritional import nutritional_repository
+from repository import patient_repository
+from repository.nutritional.nutritional_nrs_repository import upsert_nrs_component_a
 from security.permission import Permission
+from services import patient_service
 from services.nutritional import nutritional_active_patients_service
+from services.nutritional.nutritional_nrs_service import recalculate_nrs
 import logging
 
 from utils import status
@@ -474,3 +478,38 @@ def _handle_d7_closure(nratendimento: int, prox_visita: str, idusuario: int):
             dt_prevista=dt_prevista,
             idusuario=idusuario
         )
+
+
+@has_permission(Permission.WRITE_NUTRITIONAL)
+def save_nrs_component_a(nratendimento: int, nut: int, user_permissions):
+    if nut not in (0, 1, 2, 3):
+        raise ValidationError(
+            "nut deve ser 0, 1, 2 ou 3",
+            "errors.invalidParam",
+            status.HTTP_400_BAD_REQUEST,
+        )
+
+    row = patient_repository.get_patient_mnutric(admissionNumber=nratendimento)
+    if row is None:
+        raise ValidationError(
+            "Paciente não encontrado",
+            "errors.notFound",
+            status.HTTP_404_NOT_FOUND,
+        )
+    patient = Patient()
+    patient.admissionNumber = row.admissionNumber
+    patient.birthdate = row.birthdate
+    patient.id_icd = row.id_icd or ""
+
+    upsert_nrs_component_a(nratendimento, nut)
+    nrs_score, _ = recalculate_nrs(patient, is_icu=False)
+    db.session.commit()
+
+    return {
+        "nrs_nut": nrs_score.nrs_nut,
+        "nrs_doenca": nrs_score.nrs_doenca,
+        "nrs_idade": nrs_score.nrs_idade,
+        "nrs_total": nrs_score.nrs_total,
+        "classificacao": nrs_score.classificacao,
+        "nrs_completo": nrs_score.nrs_completo,
+    }


### PR DESCRIPTION
## Summary

- Novo endpoint `PUT /nutritional/patients/{nratendimento}/nrs-a` para persistir o Componente A (comprometimento nutricional) do NRS-2002
- Faz upsert em `nutricional_nrs` e recalcula `nutricional_triagem` imediatamente
- Corrige o gap onde `handleSaveNrs` no FE só atualizava estado Redux local sem chamar API

## Contrato

```
PUT /nutritional/patients/{nratendimento}/nrs-a
{ "nut": 0 | 1 | 2 | 3 }

200 → { nrs_nut, nrs_doenca, nrs_idade, nrs_total, classificacao, nrs_completo }
400 → nut fora de {0, 1, 2, 3}
404 → paciente não encontrado
```

## Arquivos alterados

- `repository/nutritional/nutritional_nrs_repository.py` — `upsert_nrs_component_a`
- `services/nutritional/nutritional_patient_service.py` — `save_nrs_component_a`
- `routes/nutritional/nutritional_patients.py` — rota `PUT /nrs-a`
- `docker-compose.nitra.yml` — migrações V7–V11 adicionadas

## Test plan

- [ ] `PUT /nrs-a` com `nut=2` → retorna `nrs_completo: true` e score correto
- [ ] `PUT /nrs-a` com `nut=0` → retorna `classificacao: "bx"`, `nrs_total = doenca + idade`
- [ ] `PUT /nrs-a` com `nut=5` → 400 `errors.invalidParam`
- [ ] `PUT /nrs-a` com paciente inexistente → 404 `errors.notFound`
- [ ] Segunda chamada no mesmo paciente (update) → não duplica linha em `nutricional_nrs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)